### PR TITLE
Fixing `cron.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The apache image contains a webserver and exposes port 80.
 To start the container type:
 
 ```console
-$ docker run -d -p 8080:80 --link some-mysql:mysql friendica
+$ docker run -d -p 8080:80 --link some-mysql:mysql friendica/server
 ```
 
 Now you can access the Friendica installation wizard at http://localhost:8080/ from your host system.

--- a/develop/apache/cron.sh
+++ b/develop/apache/cron.sh
@@ -1,14 +1,11 @@
 #!/bin/sh
-set -eu
-
-trap "break;exit" SIGHUP SIGINT SIGTERM
+trap "break;exit" HUP INT TERM
 
 while [ ! -f /var/www/html/.htconfig.php ]; do
     sleep 1
 done
 
 while true; do
-    cd /var/www/html
     php -f /var/www/html/bin/worker.php
     sleep 10m
 done

--- a/develop/fpm-alpine/cron.sh
+++ b/develop/fpm-alpine/cron.sh
@@ -1,14 +1,11 @@
 #!/bin/sh
-set -eu
-
-trap "break;exit" SIGHUP SIGINT SIGTERM
+trap "break;exit" HUP INT TERM
 
 while [ ! -f /var/www/html/.htconfig.php ]; do
     sleep 1
 done
 
 while true; do
-    cd /var/www/html
     php -f /var/www/html/bin/worker.php
     sleep 10m
 done

--- a/develop/fpm/cron.sh
+++ b/develop/fpm/cron.sh
@@ -1,14 +1,11 @@
 #!/bin/sh
-set -eu
-
-trap "break;exit" SIGHUP SIGINT SIGTERM
+trap "break;exit" HUP INT TERM
 
 while [ ! -f /var/www/html/.htconfig.php ]; do
     sleep 1
 done
 
 while true; do
-    cd /var/www/html
     php -f /var/www/html/bin/worker.php
     sleep 10m
 done

--- a/stable/apache/cron.sh
+++ b/stable/apache/cron.sh
@@ -1,14 +1,11 @@
 #!/bin/sh
-set -eu
-
-trap "break;exit" SIGHUP SIGINT SIGTERM
+trap "break;exit" HUP INT TERM
 
 while [ ! -f /var/www/html/.htconfig.php ]; do
     sleep 1
 done
 
 while true; do
-    cd /var/www/html
-    php -f /var/www/html/bin/worker.php
+    php -f /var/www/html/scripts/worker.php
     sleep 10m
 done

--- a/stable/fpm-alpine/cron.sh
+++ b/stable/fpm-alpine/cron.sh
@@ -1,14 +1,11 @@
 #!/bin/sh
-set -eu
-
-trap "break;exit" SIGHUP SIGINT SIGTERM
+trap "break;exit" HUP INT TERM
 
 while [ ! -f /var/www/html/.htconfig.php ]; do
     sleep 1
 done
 
 while true; do
-    cd /var/www/html
-    php -f /var/www/html/bin/worker.php
+    php -f /var/www/html/scripts/worker.php
     sleep 10m
 done

--- a/stable/fpm/cron.sh
+++ b/stable/fpm/cron.sh
@@ -1,14 +1,11 @@
 #!/bin/sh
-set -eu
-
-trap "break;exit" SIGHUP SIGINT SIGTERM
+trap "break;exit" HUP INT TERM
 
 while [ ! -f /var/www/html/.htconfig.php ]; do
     sleep 1
 done
 
 while true; do
-    cd /var/www/html
-    php -f /var/www/html/bin/worker.php
+    php -f /var/www/html/scripts/worker.php
     sleep 10m
 done


### PR DESCRIPTION
Had some issues with `SIG[*]` (SIGHUP, SIGINT, SIGTERM) because they are not working with `/bin/sh` very well (see https://unix.stackexchange.com/questions/314554/why-do-i-get-an-error-message-when-trying-to-trap-a-sigint-signal )

So I changed them to HUP, INT, TERM.