### PR TITLE
Fixing DNS_PTR & DNS_CNAME problems in docker environments.

### DIFF
--- a/develop/apache/bin/friendica
+++ b/develop/apache/bin/friendica
@@ -137,6 +137,8 @@ copy_sources() {
     if [ -f $WORKDIR/view/smarty3 ]; then
         chmod 777 $WORKDIR/view/smarty3
     fi
+
+    custom_patch
   fi
 }
 
@@ -159,8 +161,6 @@ install() {
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/html/.htconfig.php"
-    # TODO Pull Request for dba Change
-    run_as "sed -i 's/\s+\sDNS_CNAME//g' ${WORKDIR}/include/dba.php"
     console "autoinstall -f .htconfig.php"
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
@@ -197,6 +197,13 @@ sendmail() {
   nohup /etc/init.d/sendmail start > /dev/null 2>&1 &
 }
 
+# this method will patch Friendica sources in the WORKDIR because of special behaviors in Docker environments
+custom_patch() {
+  # TODO Pull Request for dba Change
+  run_as "sed -i 's/\s+\sDNS_CNAME//g' ${WORKDIR}/include/dba.php"
+  run_as "sed -i 's/\s+\sDNS_PTR//g' ${WORKDIR}/include/dba.php"
+}
+
 if [ $# -eq 0 ]; then
   friendica_help
   exit 0
@@ -207,6 +214,7 @@ case "$1" in
   update) shift; update "$@" ;;
   console) shift; console "$@" ;;
   composer) shift; composer "$@" ;;
+  patch) shift; custom_patch "$@" ;;
   sendmail) shift; sendmail "$@" ;;
   *) friendica_help ;;
 esac

--- a/develop/apache/entrypoint.sh
+++ b/develop/apache/entrypoint.sh
@@ -2,6 +2,7 @@
 set -eu
 
 friendica install -q
+friendica patch -q
 friendica sendmail -q
 
 exec "$@"

--- a/develop/fpm-alpine/bin/friendica
+++ b/develop/fpm-alpine/bin/friendica
@@ -137,6 +137,8 @@ copy_sources() {
     if [ -f $WORKDIR/view/smarty3 ]; then
         chmod 777 $WORKDIR/view/smarty3
     fi
+
+    custom_patch
   fi
 }
 
@@ -159,8 +161,6 @@ install() {
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/html/.htconfig.php"
-    # TODO Pull Request for dba Change
-    run_as "sed -i 's/\s+\sDNS_CNAME//g' ${WORKDIR}/include/dba.php"
     console "autoinstall -f .htconfig.php"
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
@@ -197,6 +197,13 @@ sendmail() {
   nohup /etc/init.d/sendmail start > /dev/null 2>&1 &
 }
 
+# this method will patch Friendica sources in the WORKDIR because of special behaviors in Docker environments
+custom_patch() {
+  # TODO Pull Request for dba Change
+  run_as "sed -i 's/\s+\sDNS_CNAME//g' ${WORKDIR}/include/dba.php"
+  run_as "sed -i 's/\s+\sDNS_PTR//g' ${WORKDIR}/include/dba.php"
+}
+
 if [ $# -eq 0 ]; then
   friendica_help
   exit 0
@@ -207,6 +214,7 @@ case "$1" in
   update) shift; update "$@" ;;
   console) shift; console "$@" ;;
   composer) shift; composer "$@" ;;
+  patch) shift; custom_patch "$@" ;;
   sendmail) shift; sendmail "$@" ;;
   *) friendica_help ;;
 esac

--- a/develop/fpm-alpine/entrypoint.sh
+++ b/develop/fpm-alpine/entrypoint.sh
@@ -2,6 +2,7 @@
 set -eu
 
 friendica install -q
+friendica patch -q
 friendica sendmail -q
 
 exec "$@"

--- a/develop/fpm/bin/friendica
+++ b/develop/fpm/bin/friendica
@@ -137,6 +137,8 @@ copy_sources() {
     if [ -f $WORKDIR/view/smarty3 ]; then
         chmod 777 $WORKDIR/view/smarty3
     fi
+
+    custom_patch
   fi
 }
 
@@ -159,8 +161,6 @@ install() {
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/html/.htconfig.php"
-    # TODO Pull Request for dba Change
-    run_as "sed -i 's/\s+\sDNS_CNAME//g' ${WORKDIR}/include/dba.php"
     console "autoinstall -f .htconfig.php"
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
@@ -197,6 +197,13 @@ sendmail() {
   nohup /etc/init.d/sendmail start > /dev/null 2>&1 &
 }
 
+# this method will patch Friendica sources in the WORKDIR because of special behaviors in Docker environments
+custom_patch() {
+  # TODO Pull Request for dba Change
+  run_as "sed -i 's/\s+\sDNS_CNAME//g' ${WORKDIR}/include/dba.php"
+  run_as "sed -i 's/\s+\sDNS_PTR//g' ${WORKDIR}/include/dba.php"
+}
+
 if [ $# -eq 0 ]; then
   friendica_help
   exit 0
@@ -207,6 +214,7 @@ case "$1" in
   update) shift; update "$@" ;;
   console) shift; console "$@" ;;
   composer) shift; composer "$@" ;;
+  patch) shift; custom_patch "$@" ;;
   sendmail) shift; sendmail "$@" ;;
   *) friendica_help ;;
 esac

--- a/develop/fpm/entrypoint.sh
+++ b/develop/fpm/entrypoint.sh
@@ -2,6 +2,7 @@
 set -eu
 
 friendica install -q
+friendica patch -q
 friendica sendmail -q
 
 exec "$@"

--- a/stable/apache/bin/friendica
+++ b/stable/apache/bin/friendica
@@ -137,6 +137,8 @@ copy_sources() {
     if [ -f $WORKDIR/view/smarty3 ]; then
         chmod 777 $WORKDIR/view/smarty3
     fi
+
+    custom_patch
   fi
 }
 
@@ -159,8 +161,6 @@ install() {
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/html/.htconfig.php"
-    # TODO Pull Request for dba Change
-    run_as "sed -i 's/\s+\sDNS_CNAME//g' ${WORKDIR}/include/dba.php"
     console "autoinstall -f .htconfig.php"
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
@@ -197,6 +197,13 @@ sendmail() {
   nohup /etc/init.d/sendmail start > /dev/null 2>&1 &
 }
 
+# this method will patch Friendica sources in the WORKDIR because of special behaviors in Docker environments
+custom_patch() {
+  # TODO Pull Request for dba Change
+  run_as "sed -i 's/\s+\sDNS_CNAME//g' ${WORKDIR}/include/dba.php"
+  run_as "sed -i 's/\s+\sDNS_PTR//g' ${WORKDIR}/include/dba.php"
+}
+
 if [ $# -eq 0 ]; then
   friendica_help
   exit 0
@@ -207,6 +214,7 @@ case "$1" in
   update) shift; update "$@" ;;
   console) shift; console "$@" ;;
   composer) shift; composer "$@" ;;
+  patch) shift; custom_patch "$@" ;;
   sendmail) shift; sendmail "$@" ;;
   *) friendica_help ;;
 esac

--- a/stable/apache/entrypoint.sh
+++ b/stable/apache/entrypoint.sh
@@ -2,6 +2,7 @@
 set -eu
 
 friendica install -q
+friendica patch -q
 friendica sendmail -q
 
 exec "$@"

--- a/stable/fpm-alpine/bin/friendica
+++ b/stable/fpm-alpine/bin/friendica
@@ -137,6 +137,8 @@ copy_sources() {
     if [ -f $WORKDIR/view/smarty3 ]; then
         chmod 777 $WORKDIR/view/smarty3
     fi
+
+    custom_patch
   fi
 }
 
@@ -159,8 +161,6 @@ install() {
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/html/.htconfig.php"
-    # TODO Pull Request for dba Change
-    run_as "sed -i 's/\s+\sDNS_CNAME//g' ${WORKDIR}/include/dba.php"
     console "autoinstall -f .htconfig.php"
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
@@ -197,6 +197,13 @@ sendmail() {
   nohup /etc/init.d/sendmail start > /dev/null 2>&1 &
 }
 
+# this method will patch Friendica sources in the WORKDIR because of special behaviors in Docker environments
+custom_patch() {
+  # TODO Pull Request for dba Change
+  run_as "sed -i 's/\s+\sDNS_CNAME//g' ${WORKDIR}/include/dba.php"
+  run_as "sed -i 's/\s+\sDNS_PTR//g' ${WORKDIR}/include/dba.php"
+}
+
 if [ $# -eq 0 ]; then
   friendica_help
   exit 0
@@ -207,6 +214,7 @@ case "$1" in
   update) shift; update "$@" ;;
   console) shift; console "$@" ;;
   composer) shift; composer "$@" ;;
+  patch) shift; custom_patch "$@" ;;
   sendmail) shift; sendmail "$@" ;;
   *) friendica_help ;;
 esac

--- a/stable/fpm-alpine/entrypoint.sh
+++ b/stable/fpm-alpine/entrypoint.sh
@@ -2,6 +2,7 @@
 set -eu
 
 friendica install -q
+friendica patch -q
 friendica sendmail -q
 
 exec "$@"

--- a/stable/fpm/bin/friendica
+++ b/stable/fpm/bin/friendica
@@ -137,6 +137,8 @@ copy_sources() {
     if [ -f $WORKDIR/view/smarty3 ]; then
         chmod 777 $WORKDIR/view/smarty3
     fi
+
+    custom_patch
   fi
 }
 
@@ -159,8 +161,6 @@ install() {
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/html/.htconfig.php"
-    # TODO Pull Request for dba Change
-    run_as "sed -i 's/\s+\sDNS_CNAME//g' ${WORKDIR}/include/dba.php"
     console "autoinstall -f .htconfig.php"
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
@@ -197,6 +197,13 @@ sendmail() {
   nohup /etc/init.d/sendmail start > /dev/null 2>&1 &
 }
 
+# this method will patch Friendica sources in the WORKDIR because of special behaviors in Docker environments
+custom_patch() {
+  # TODO Pull Request for dba Change
+  run_as "sed -i 's/\s+\sDNS_CNAME//g' ${WORKDIR}/include/dba.php"
+  run_as "sed -i 's/\s+\sDNS_PTR//g' ${WORKDIR}/include/dba.php"
+}
+
 if [ $# -eq 0 ]; then
   friendica_help
   exit 0
@@ -207,6 +214,7 @@ case "$1" in
   update) shift; update "$@" ;;
   console) shift; console "$@" ;;
   composer) shift; composer "$@" ;;
+  patch) shift; custom_patch "$@" ;;
   sendmail) shift; sendmail "$@" ;;
   *) friendica_help ;;
 esac

--- a/stable/fpm/entrypoint.sh
+++ b/stable/fpm/entrypoint.sh
@@ -2,6 +2,7 @@
 set -eu
 
 friendica install -q
+friendica patch -q
 friendica sendmail -q
 
 exec "$@"


### PR DESCRIPTION
Fix for #6 

In docker environments, the DNS_PTR and DNS_CNAME doesn't work very well. So I made a patch to remove them from `include/dba.php` ;-)