### PR TITLE
Bugfix `friendica console` command

### DIFF
--- a/.bin/friendica
+++ b/.bin/friendica
@@ -95,8 +95,10 @@ friendica_help() {
 
 # executes the Friendica console
 console() {
-  cd $WORKDIR
-  php $WORKDIR/bin/console.php "$@"
+  if [ -f $WORKDIR/bin/console.php ]; then
+    cd $WORKDIR
+    php $WORKDIR/bin/console.php "$@"
+  fi
 }
 
 # executes the composer.phar binary of Friendica
@@ -157,15 +159,13 @@ install() {
   copy_sources
 
   log 'Installing Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
+  composer install
 
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console "autoinstall -f .htconfig.php"
+    console autoinstall -f .htconfig.php
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
   fi
@@ -181,10 +181,9 @@ update() {
   copy_sources
 
   log 'Upgrading Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
-  console "dbstructure update"
+
+  composer install
+  console dbstructure update
 }
 
 sendmail() {

--- a/2018.05/apache/bin/friendica
+++ b/2018.05/apache/bin/friendica
@@ -95,8 +95,10 @@ friendica_help() {
 
 # executes the Friendica console
 console() {
-  cd $WORKDIR
-  php $WORKDIR/bin/console.php "$@"
+  if [ -f $WORKDIR/bin/console.php ]; then
+    cd $WORKDIR
+    php $WORKDIR/bin/console.php "$@"
+  fi
 }
 
 # executes the composer.phar binary of Friendica
@@ -157,15 +159,13 @@ install() {
   copy_sources
 
   log 'Installing Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
+  composer install
 
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console "autoinstall -f .htconfig.php"
+    console autoinstall -f .htconfig.php
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
   fi
@@ -181,10 +181,9 @@ update() {
   copy_sources
 
   log 'Upgrading Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
-  console "dbstructure update"
+
+  composer install
+  console dbstructure update
 }
 
 sendmail() {

--- a/2018.05/fpm-alpine/bin/friendica
+++ b/2018.05/fpm-alpine/bin/friendica
@@ -95,8 +95,10 @@ friendica_help() {
 
 # executes the Friendica console
 console() {
-  cd $WORKDIR
-  php $WORKDIR/bin/console.php "$@"
+  if [ -f $WORKDIR/bin/console.php ]; then
+    cd $WORKDIR
+    php $WORKDIR/bin/console.php "$@"
+  fi
 }
 
 # executes the composer.phar binary of Friendica
@@ -157,15 +159,13 @@ install() {
   copy_sources
 
   log 'Installing Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
+  composer install
 
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console "autoinstall -f .htconfig.php"
+    console autoinstall -f .htconfig.php
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
   fi
@@ -181,10 +181,9 @@ update() {
   copy_sources
 
   log 'Upgrading Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
-  console "dbstructure update"
+
+  composer install
+  console dbstructure update
 }
 
 sendmail() {

--- a/2018.05/fpm/bin/friendica
+++ b/2018.05/fpm/bin/friendica
@@ -95,8 +95,10 @@ friendica_help() {
 
 # executes the Friendica console
 console() {
-  cd $WORKDIR
-  php $WORKDIR/bin/console.php "$@"
+  if [ -f $WORKDIR/bin/console.php ]; then
+    cd $WORKDIR
+    php $WORKDIR/bin/console.php "$@"
+  fi
 }
 
 # executes the composer.phar binary of Friendica
@@ -157,15 +159,13 @@ install() {
   copy_sources
 
   log 'Installing Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
+  composer install
 
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console "autoinstall -f .htconfig.php"
+    console autoinstall -f .htconfig.php
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
   fi
@@ -181,10 +181,9 @@ update() {
   copy_sources
 
   log 'Upgrading Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
-  console "dbstructure update"
+
+  composer install
+  console dbstructure update
 }
 
 sendmail() {

--- a/2018.08-dev/apache/bin/friendica
+++ b/2018.08-dev/apache/bin/friendica
@@ -95,8 +95,10 @@ friendica_help() {
 
 # executes the Friendica console
 console() {
-  cd $WORKDIR
-  php $WORKDIR/bin/console.php "$@"
+  if [ -f $WORKDIR/bin/console.php ]; then
+    cd $WORKDIR
+    php $WORKDIR/bin/console.php "$@"
+  fi
 }
 
 # executes the composer.phar binary of Friendica
@@ -157,15 +159,13 @@ install() {
   copy_sources
 
   log 'Installing Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
+  composer install
 
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console "autoinstall -f .htconfig.php"
+    console autoinstall -f .htconfig.php
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
   fi
@@ -181,10 +181,9 @@ update() {
   copy_sources
 
   log 'Upgrading Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
-  console "dbstructure update"
+
+  composer install
+  console dbstructure update
 }
 
 sendmail() {

--- a/2018.08-dev/fpm-alpine/bin/friendica
+++ b/2018.08-dev/fpm-alpine/bin/friendica
@@ -95,8 +95,10 @@ friendica_help() {
 
 # executes the Friendica console
 console() {
-  cd $WORKDIR
-  php $WORKDIR/bin/console.php "$@"
+  if [ -f $WORKDIR/bin/console.php ]; then
+    cd $WORKDIR
+    php $WORKDIR/bin/console.php "$@"
+  fi
 }
 
 # executes the composer.phar binary of Friendica
@@ -157,15 +159,13 @@ install() {
   copy_sources
 
   log 'Installing Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
+  composer install
 
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console "autoinstall -f .htconfig.php"
+    console autoinstall -f .htconfig.php
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
   fi
@@ -181,10 +181,9 @@ update() {
   copy_sources
 
   log 'Upgrading Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
-  console "dbstructure update"
+
+  composer install
+  console dbstructure update
 }
 
 sendmail() {

--- a/2018.08-dev/fpm/bin/friendica
+++ b/2018.08-dev/fpm/bin/friendica
@@ -95,8 +95,10 @@ friendica_help() {
 
 # executes the Friendica console
 console() {
-  cd $WORKDIR
-  php $WORKDIR/bin/console.php "$@"
+  if [ -f $WORKDIR/bin/console.php ]; then
+    cd $WORKDIR
+    php $WORKDIR/bin/console.php "$@"
+  fi
 }
 
 # executes the composer.phar binary of Friendica
@@ -157,15 +159,13 @@ install() {
   copy_sources
 
   log 'Installing Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
+  composer install
 
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      "$AUTOINSTALL" == "true"; then
     run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console "autoinstall -f .htconfig.php"
+    console autoinstall -f .htconfig.php
     # TODO Workaround because of a strange permission issue
     rm -fr ${WORKDIR}/view/smarty3/compiled
   fi
@@ -181,10 +181,9 @@ update() {
   copy_sources
 
   log 'Upgrading Friendica'
-  if echo "$FRIENDICA_VERSION" | grep -Eq '^.*(\-dev|-rc)'; then
-    composer "install"
-  fi
-  console "dbstructure update"
+
+  composer install
+  console dbstructure update
 }
 
 sendmail() {


### PR DESCRIPTION
- added to every installation type
- fixing the function call parameters

Until 3.6, there was a "full" source-file with all the vendor-stuff.
Now we have to use the composer for every type of installation and therefore we have to activate it in the docker-installations aswell.

And there were issues with the function call parameters (quoting the arguments makes two arguments to one argument with whitespace)