### PR TITLE
Added Datbase retry checks (if Friendica is faster than the DB)

### DIFF
--- a/.bin/friendica
+++ b/.bin/friendica
@@ -98,6 +98,39 @@ friendica_help() {
   exit 0
 }
 
+check_database() {
+  TERM=dumb php -- <<'EOPHP'
+<?php
+// database might not exist, so let's wait for it (just to be safe)
+$stderr = fopen('php://stderr', 'w');
+
+require_once '/usr/src/config/htconfig.php';
+
+$connection = "mysql:host=".$db_host.";dbname=".$db_data;
+
+$maxTries = 10;
+$connected = false;
+do {
+    try {
+         // This docker image is using the PDO library
+        $mysql = @new PDO($connection, $db_user, $db_pass);
+        $connected = true;
+    } catch (PDOException $e) {
+        fwrite($stderr, "\nMySQL Connection Error: " . $e . "\n");
+        $connected = false;
+        --$maxTries;
+        if ($maxTries <= 0) {
+            exit(1);
+        }
+        sleep(3);
+    }
+} while (!$connected);
+
+unset($db_user, $db_pass, $db_host, $db_data, $port, $socket);
+?>
+EOPHP
+}
+
 # executes the Friendica console
 console() {
   if [ -f $WORKDIR/bin/console.php ]; then
@@ -177,10 +210,12 @@ install() {
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      [ "$AUTOINSTALL" = "true" ]; then
-    run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console autoinstall -f .htconfig.php
-    # TODO Workaround because of a strange permission issue
-    rm -fr ${WORKDIR}/view/smarty3/compiled
+    if check_database; then
+      run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
+      console autoinstall -f .htconfig.php
+      # TODO Workaround because of a strange permission issue
+      rm -fr ${WORKDIR}/view/smarty3/compiled
+    fi
   fi
 }
 

--- a/2018.05/apache/bin/friendica
+++ b/2018.05/apache/bin/friendica
@@ -116,7 +116,7 @@ do {
         $mysql = @new PDO($connection, $db_user, $db_pass);
         $connected = true;
     } catch (PDOException $e) {
-        fwrite($stderr, "MySQL Connection Error\n");
+        fwrite($stderr, "\nMySQL Connection Error: " . $e . "\n");
         $connected = false;
         --$maxTries;
         if ($maxTries <= 0) {

--- a/2018.05/apache/bin/friendica
+++ b/2018.05/apache/bin/friendica
@@ -98,6 +98,39 @@ friendica_help() {
   exit 0
 }
 
+check_database() {
+  TERM=dumb php -- <<'EOPHP'
+<?php
+// database might not exist, so let's wait for it (just to be safe)
+$stderr = fopen('php://stderr', 'w');
+
+require_once '/usr/src/config/htconfig.php';
+
+$connection = "mysql:host=".$db_host.";dbname=".$db_data;
+
+$maxTries = 10;
+$connected = false;
+do {
+    try {
+         // This docker image is using the PDO library
+        $mysql = @new PDO($connection, $db_user, $db_pass);
+        $connected = true;
+    } catch (PDOException $e) {
+        fwrite($stderr, "MySQL Connection Error\n");
+        $connected = false;
+        --$maxTries;
+        if ($maxTries <= 0) {
+            exit(1);
+        }
+        sleep(3);
+    }
+} while (!$connected);
+
+unset($db_user, $db_pass, $db_host, $db_data, $port, $socket);
+?>
+EOPHP
+}
+
 # executes the Friendica console
 console() {
   if [ -f $WORKDIR/bin/console.php ]; then
@@ -177,10 +210,12 @@ install() {
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      [ "$AUTOINSTALL" = "true" ]; then
-    run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console autoinstall -f .htconfig.php
-    # TODO Workaround because of a strange permission issue
-    rm -fr ${WORKDIR}/view/smarty3/compiled
+    if check_database; then
+      run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
+      console autoinstall -f .htconfig.php
+      # TODO Workaround because of a strange permission issue
+      rm -fr ${WORKDIR}/view/smarty3/compiled
+    fi
   fi
 }
 

--- a/2018.05/fpm-alpine/bin/friendica
+++ b/2018.05/fpm-alpine/bin/friendica
@@ -116,7 +116,7 @@ do {
         $mysql = @new PDO($connection, $db_user, $db_pass);
         $connected = true;
     } catch (PDOException $e) {
-        fwrite($stderr, "MySQL Connection Error\n");
+        fwrite($stderr, "\nMySQL Connection Error: " . $e . "\n");
         $connected = false;
         --$maxTries;
         if ($maxTries <= 0) {

--- a/2018.05/fpm-alpine/bin/friendica
+++ b/2018.05/fpm-alpine/bin/friendica
@@ -98,6 +98,39 @@ friendica_help() {
   exit 0
 }
 
+check_database() {
+  TERM=dumb php -- <<'EOPHP'
+<?php
+// database might not exist, so let's wait for it (just to be safe)
+$stderr = fopen('php://stderr', 'w');
+
+require_once '/usr/src/config/htconfig.php';
+
+$connection = "mysql:host=".$db_host.";dbname=".$db_data;
+
+$maxTries = 10;
+$connected = false;
+do {
+    try {
+         // This docker image is using the PDO library
+        $mysql = @new PDO($connection, $db_user, $db_pass);
+        $connected = true;
+    } catch (PDOException $e) {
+        fwrite($stderr, "MySQL Connection Error\n");
+        $connected = false;
+        --$maxTries;
+        if ($maxTries <= 0) {
+            exit(1);
+        }
+        sleep(3);
+    }
+} while (!$connected);
+
+unset($db_user, $db_pass, $db_host, $db_data, $port, $socket);
+?>
+EOPHP
+}
+
 # executes the Friendica console
 console() {
   if [ -f $WORKDIR/bin/console.php ]; then
@@ -177,10 +210,12 @@ install() {
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      [ "$AUTOINSTALL" = "true" ]; then
-    run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console autoinstall -f .htconfig.php
-    # TODO Workaround because of a strange permission issue
-    rm -fr ${WORKDIR}/view/smarty3/compiled
+    if check_database; then
+      run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
+      console autoinstall -f .htconfig.php
+      # TODO Workaround because of a strange permission issue
+      rm -fr ${WORKDIR}/view/smarty3/compiled
+    fi
   fi
 }
 

--- a/2018.05/fpm/bin/friendica
+++ b/2018.05/fpm/bin/friendica
@@ -116,7 +116,7 @@ do {
         $mysql = @new PDO($connection, $db_user, $db_pass);
         $connected = true;
     } catch (PDOException $e) {
-        fwrite($stderr, "MySQL Connection Error\n");
+        fwrite($stderr, "\nMySQL Connection Error: " . $e . "\n");
         $connected = false;
         --$maxTries;
         if ($maxTries <= 0) {

--- a/2018.05/fpm/bin/friendica
+++ b/2018.05/fpm/bin/friendica
@@ -98,6 +98,39 @@ friendica_help() {
   exit 0
 }
 
+check_database() {
+  TERM=dumb php -- <<'EOPHP'
+<?php
+// database might not exist, so let's wait for it (just to be safe)
+$stderr = fopen('php://stderr', 'w');
+
+require_once '/usr/src/config/htconfig.php';
+
+$connection = "mysql:host=".$db_host.";dbname=".$db_data;
+
+$maxTries = 10;
+$connected = false;
+do {
+    try {
+         // This docker image is using the PDO library
+        $mysql = @new PDO($connection, $db_user, $db_pass);
+        $connected = true;
+    } catch (PDOException $e) {
+        fwrite($stderr, "MySQL Connection Error\n");
+        $connected = false;
+        --$maxTries;
+        if ($maxTries <= 0) {
+            exit(1);
+        }
+        sleep(3);
+    }
+} while (!$connected);
+
+unset($db_user, $db_pass, $db_host, $db_data, $port, $socket);
+?>
+EOPHP
+}
+
 # executes the Friendica console
 console() {
   if [ -f $WORKDIR/bin/console.php ]; then
@@ -177,10 +210,12 @@ install() {
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      [ "$AUTOINSTALL" = "true" ]; then
-    run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console autoinstall -f .htconfig.php
-    # TODO Workaround because of a strange permission issue
-    rm -fr ${WORKDIR}/view/smarty3/compiled
+    if check_database; then
+      run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
+      console autoinstall -f .htconfig.php
+      # TODO Workaround because of a strange permission issue
+      rm -fr ${WORKDIR}/view/smarty3/compiled
+    fi
   fi
 }
 

--- a/2018.08-dev/apache/bin/friendica
+++ b/2018.08-dev/apache/bin/friendica
@@ -116,7 +116,7 @@ do {
         $mysql = @new PDO($connection, $db_user, $db_pass);
         $connected = true;
     } catch (PDOException $e) {
-        fwrite($stderr, "MySQL Connection Error\n");
+        fwrite($stderr, "\nMySQL Connection Error: " . $e . "\n");
         $connected = false;
         --$maxTries;
         if ($maxTries <= 0) {

--- a/2018.08-dev/apache/bin/friendica
+++ b/2018.08-dev/apache/bin/friendica
@@ -98,6 +98,39 @@ friendica_help() {
   exit 0
 }
 
+check_database() {
+  TERM=dumb php -- <<'EOPHP'
+<?php
+// database might not exist, so let's wait for it (just to be safe)
+$stderr = fopen('php://stderr', 'w');
+
+require_once '/usr/src/config/htconfig.php';
+
+$connection = "mysql:host=".$db_host.";dbname=".$db_data;
+
+$maxTries = 10;
+$connected = false;
+do {
+    try {
+         // This docker image is using the PDO library
+        $mysql = @new PDO($connection, $db_user, $db_pass);
+        $connected = true;
+    } catch (PDOException $e) {
+        fwrite($stderr, "MySQL Connection Error\n");
+        $connected = false;
+        --$maxTries;
+        if ($maxTries <= 0) {
+            exit(1);
+        }
+        sleep(3);
+    }
+} while (!$connected);
+
+unset($db_user, $db_pass, $db_host, $db_data, $port, $socket);
+?>
+EOPHP
+}
+
 # executes the Friendica console
 console() {
   if [ -f $WORKDIR/bin/console.php ]; then
@@ -177,10 +210,12 @@ install() {
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      [ "$AUTOINSTALL" = "true" ]; then
-    run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console autoinstall -f .htconfig.php
-    # TODO Workaround because of a strange permission issue
-    rm -fr ${WORKDIR}/view/smarty3/compiled
+    if check_database; then
+      run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
+      console autoinstall -f .htconfig.php
+      # TODO Workaround because of a strange permission issue
+      rm -fr ${WORKDIR}/view/smarty3/compiled
+    fi
   fi
 }
 

--- a/2018.08-dev/fpm-alpine/bin/friendica
+++ b/2018.08-dev/fpm-alpine/bin/friendica
@@ -116,7 +116,7 @@ do {
         $mysql = @new PDO($connection, $db_user, $db_pass);
         $connected = true;
     } catch (PDOException $e) {
-        fwrite($stderr, "MySQL Connection Error\n");
+        fwrite($stderr, "\nMySQL Connection Error: " . $e . "\n");
         $connected = false;
         --$maxTries;
         if ($maxTries <= 0) {

--- a/2018.08-dev/fpm-alpine/bin/friendica
+++ b/2018.08-dev/fpm-alpine/bin/friendica
@@ -98,6 +98,39 @@ friendica_help() {
   exit 0
 }
 
+check_database() {
+  TERM=dumb php -- <<'EOPHP'
+<?php
+// database might not exist, so let's wait for it (just to be safe)
+$stderr = fopen('php://stderr', 'w');
+
+require_once '/usr/src/config/htconfig.php';
+
+$connection = "mysql:host=".$db_host.";dbname=".$db_data;
+
+$maxTries = 10;
+$connected = false;
+do {
+    try {
+         // This docker image is using the PDO library
+        $mysql = @new PDO($connection, $db_user, $db_pass);
+        $connected = true;
+    } catch (PDOException $e) {
+        fwrite($stderr, "MySQL Connection Error\n");
+        $connected = false;
+        --$maxTries;
+        if ($maxTries <= 0) {
+            exit(1);
+        }
+        sleep(3);
+    }
+} while (!$connected);
+
+unset($db_user, $db_pass, $db_host, $db_data, $port, $socket);
+?>
+EOPHP
+}
+
 # executes the Friendica console
 console() {
   if [ -f $WORKDIR/bin/console.php ]; then
@@ -177,10 +210,12 @@ install() {
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      [ "$AUTOINSTALL" = "true" ]; then
-    run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console autoinstall -f .htconfig.php
-    # TODO Workaround because of a strange permission issue
-    rm -fr ${WORKDIR}/view/smarty3/compiled
+    if check_database; then
+      run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
+      console autoinstall -f .htconfig.php
+      # TODO Workaround because of a strange permission issue
+      rm -fr ${WORKDIR}/view/smarty3/compiled
+    fi
   fi
 }
 

--- a/2018.08-dev/fpm/bin/friendica
+++ b/2018.08-dev/fpm/bin/friendica
@@ -116,7 +116,7 @@ do {
         $mysql = @new PDO($connection, $db_user, $db_pass);
         $connected = true;
     } catch (PDOException $e) {
-        fwrite($stderr, "MySQL Connection Error\n");
+        fwrite($stderr, "\nMySQL Connection Error: " . $e . "\n");
         $connected = false;
         --$maxTries;
         if ($maxTries <= 0) {

--- a/2018.08-dev/fpm/bin/friendica
+++ b/2018.08-dev/fpm/bin/friendica
@@ -98,6 +98,39 @@ friendica_help() {
   exit 0
 }
 
+check_database() {
+  TERM=dumb php -- <<'EOPHP'
+<?php
+// database might not exist, so let's wait for it (just to be safe)
+$stderr = fopen('php://stderr', 'w');
+
+require_once '/usr/src/config/htconfig.php';
+
+$connection = "mysql:host=".$db_host.";dbname=".$db_data;
+
+$maxTries = 10;
+$connected = false;
+do {
+    try {
+         // This docker image is using the PDO library
+        $mysql = @new PDO($connection, $db_user, $db_pass);
+        $connected = true;
+    } catch (PDOException $e) {
+        fwrite($stderr, "MySQL Connection Error\n");
+        $connected = false;
+        --$maxTries;
+        if ($maxTries <= 0) {
+            exit(1);
+        }
+        sleep(3);
+    }
+} while (!$connected);
+
+unset($db_user, $db_pass, $db_host, $db_data, $port, $socket);
+?>
+EOPHP
+}
+
 # executes the Friendica console
 console() {
   if [ -f $WORKDIR/bin/console.php ]; then
@@ -177,10 +210,12 @@ install() {
   if [ ! -f ${WORKDIR}/.htconfig.php ] &&
      [ -f ${SOURCEDIR}/config/htconfig.php ] &&
      [ "$AUTOINSTALL" = "true" ]; then
-    run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
-    console autoinstall -f .htconfig.php
-    # TODO Workaround because of a strange permission issue
-    rm -fr ${WORKDIR}/view/smarty3/compiled
+    if check_database; then
+      run_as "cp ${SOURCEDIR}/config/htconfig.php ${WORKDIR}/.htconfig.php"
+      console autoinstall -f .htconfig.php
+      # TODO Workaround because of a strange permission issue
+      rm -fr ${WORKDIR}/view/smarty3/compiled
+    fi
   fi
 }
 


### PR DESCRIPTION
If we start both container (db and Friendica) immediately, Friendica is sometimes faster than the database setup so we get MySQL Connection errors.

This PR will add a retry mechanism for the startup so Friendica is waiting for the database to get up.
This is the docker PR instead of https://github.com/friendica/friendica/pull/5183

A typical output (with autoinstall) would be:
```console
MySQL Connection Error
MySQL Connection Error
Initializing setup...

Using config .htconfig.php...

 Complete!


Checking basic setup...

 NOTICE: Not checking .htaccess/URL-Rewrite during CLI installation.

 Complete!


Checking database...

 Complete!


Inserting data into database...

 Complete!


Installing theme

 Complete


Saving config file...

 Complete!



Installation is finished

[Sun Jun 10 13:43:30.097149 2018] [mpm_prefork:notice] [pid 1] AH00163: Apache/2.4.10 (Debian) PHP/7.1.16 configured -- resuming normal operations
[Sun Jun 10 13:43:30.097321 2018] [core:notice] [pid 1] AH00094: Command line: 'apache2 -D FOREGROUND'
```