### PR TITLE
travis-ci improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
-dist: trusty
-sudo: required
-
-services: docker
-
 language: bash
+services: docker
 
 stages:
   - test scripts


### PR DESCRIPTION
Due to travis optimizations, we don't need  to set dist and sudo anymore.
https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures