### PR TITLE
Enhancing docker images

### DIFF
--- a/.docker-files/entrypoint.sh
+++ b/.docker-files/entrypoint.sh
@@ -141,8 +141,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
 			if [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ] && [ -n "${MYSQL_USER+x}" -o -n "${MYSQL_USERNAME+x}" ] && [ -n ${FRIENDICA_ADMIN_MAIL+x} ]; then
 				echo "Installation with environment variables"
 
-				# TODO Bug in PHP Path for automatic installation
-				#FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
+				FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
 				FRIENDICA_TZ=${FRIENDICA_TZ:-America/LosAngeles}
 				FRIENDICA_LANG=${FRIENDICA_LANG:-en}
 				MYSQL_PORT=${MYSQL_PORT:-3306}

--- a/.docker-files/upgrade.exclude
+++ b/.docker-files/upgrade.exclude
@@ -9,3 +9,4 @@
 /config/local.config.php
 /config/addon.config.php
 /storage/
+*.log

--- a/2019.04/apache/Dockerfile
+++ b/2019.04/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:7.1-apache
+FROM php:7.3-apache-stretch
 LABEL maintainer="Philipp Holzer <admin@philipp.info>"
 
 # entrypoint.sh and cron.sh dependencies
@@ -34,8 +34,6 @@ RUN set -ex; \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        libmcrypt4 \
-        libmcrypt-dev \
         imagemagick \
         libmagick++-dev \
         libmemcached-dev \
@@ -45,29 +43,43 @@ RUN set -ex; \
         librsvg2-2 \
         libcurl4-openssl-dev \
         curl \
+        libzip-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    pecl install imagick-3.4.3; \
-        docker-php-ext-enable imagick; \
-        pecl clear-cache \
-    ; \
+    \
     docker-php-ext-configure gd \
         --with-gd \
-        --enable-gd-native-ttf \
         --with-freetype-dir=/usr/include/ \
         --with-png-dir=/usr/include/ \
         --with-jpeg-dir=/usr/include/ \
     ; \
-    docker-php-ext-install -j 4 curl pdo pdo_mysql xml gd zip opcache mbstring posix ctype json iconv mcrypt \
+    docker-php-ext-install -j 4 \
+        curl \
+        pdo \
+        pdo_mysql \
+        xml \
+        gd \
+        zip \
+        opcache \
+        mbstring \
+        posix \
+        ctype \
+        json \
+        iconv \
     ; \
+    \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install memcached-3.0.4; \
-    pecl install redis-3.1.6; \
+    pecl install apcu-5.1.17; \
+    pecl install memcached-3.1.3; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \
+        apcu \
         memcached \
         redis \
+        imagick \
     ; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
@@ -84,11 +96,19 @@ RUN set -ex; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 
-RUN chown -R www-data:root /var/www; \
+RUN {\
+      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
+    } > /usr/local/etc/php/conf.d/sendmail.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
 VOLUME /var/www/html
-WORKDIR /var/www/html
 
 RUN a2enmod rewrite remoteip ;\
     {\
@@ -98,10 +118,6 @@ RUN a2enmod rewrite remoteip ;\
      echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
     a2enconf remoteip
-
-RUN {\
-      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
-    } > /usr/local/etc/php/conf.d/sendmail.ini;
 
 COPY *.sh upgrade.exclude /
 RUN chmod +x /*.sh
@@ -118,7 +134,8 @@ RUN set -ex; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     curl -fsSL -o friendica_addons.tar.gz \
         "https://github.com/friendica/friendica-addons/archive/${FRIENDICA_ADDONS}.tar.gz"; \
-    mkdir /usr/src/friendica/addon; \
+    mkdir -p /usr/src/friendica/proxy; \
+    mkdir -p /usr/src/friendica/addon; \
     tar -xzf friendica_addons.tar.gz -C /usr/src/friendica/addon --strip-components=1; \
     rm friendica_addons.tar.gz; \
     /usr/src/friendica/bin/composer.phar install --no-dev -d /usr/src/friendica;

--- a/2019.04/apache/entrypoint.sh
+++ b/2019.04/apache/entrypoint.sh
@@ -141,8 +141,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
 			if [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ] && [ -n "${MYSQL_USER+x}" -o -n "${MYSQL_USERNAME+x}" ] && [ -n ${FRIENDICA_ADMIN_MAIL+x} ]; then
 				echo "Installation with environment variables"
 
-				# TODO Bug in PHP Path for automatic installation
-				#FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
+				FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
 				FRIENDICA_TZ=${FRIENDICA_TZ:-America/LosAngeles}
 				FRIENDICA_LANG=${FRIENDICA_LANG:-en}
 				MYSQL_PORT=${MYSQL_PORT:-3306}

--- a/2019.04/apache/upgrade.exclude
+++ b/2019.04/apache/upgrade.exclude
@@ -9,3 +9,4 @@
 /config/local.config.php
 /config/addon.config.php
 /storage/
+*.log

--- a/2019.04/fpm-alpine/Dockerfile
+++ b/2019.04/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:7.1-fpm-alpine
+FROM php:7.3-fpm-alpine
 LABEL maintainer="Philipp Holzer <admin@philipp.info>"
 
 # entrypoint.sh and cron.sh dependencies
@@ -29,8 +29,6 @@ RUN set -ex; \
         imagemagick-dev \
         imagemagick \
         libtool \
-        libmcrypt \
-        libmcrypt-dev \
         libmemcached-dev \
         cyrus-sasl-dev \
         freetype \
@@ -44,26 +42,42 @@ RUN set -ex; \
         rsync \
         bzip2 \
         pcre-dev \
+        libzip-dev \
     ; \
-    pecl install imagick-3.4.3; \
-        docker-php-ext-enable imagick; \
-        pecl clear-cache; \
+    \
     docker-php-ext-configure gd \
         --with-gd \
-        --enable-gd-native-ttf \
         --with-freetype-dir=/usr/include/ \
         --with-png-dir=/usr/include/ \
         --with-jpeg-dir=/usr/include/ \
     ; \
-    docker-php-ext-install -j 4 curl pdo pdo_mysql xml gd zip opcache mbstring posix ctype json iconv mcrypt; \
+    \
+    docker-php-ext-install -j 4 \
+       curl \
+       pdo \
+       pdo_mysql \
+       xml \
+       gd \
+       zip \
+       opcache \
+       mbstring \
+       posix \
+       ctype \
+       json \
+       iconv \
+    ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install memcached-3.0.4; \
-    pecl install redis-3.1.6; \
+    pecl install APCu-5.1.17; \
+    pecl install memcached-3.1.3; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \
+    	apcu \
         memcached \
         redis \
+        imagick \
     ; \
     \
     runDeps="$( \
@@ -75,16 +89,20 @@ RUN set -ex; \
     apk add --virtual .friendica-phpext-rundeps $runDeps; \
     apk del .build-deps;
 
-RUN chown -R www-data:www-data /var/www; \
+RUN {\
+        echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
+    } > /usr/local/etc/php/conf.d/sendmail.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
 VOLUME /var/www/html
-WORKDIR /var/www/html
 
-
-RUN {\
-      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
-    } > /usr/local/etc/php/conf.d/sendmail.ini;
 
 COPY *.sh upgrade.exclude /
 RUN chmod +x /*.sh
@@ -101,7 +119,8 @@ RUN set -ex; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     curl -fsSL -o friendica_addons.tar.gz \
         "https://github.com/friendica/friendica-addons/archive/${FRIENDICA_ADDONS}.tar.gz"; \
-    mkdir /usr/src/friendica/addon; \
+    mkdir -p /usr/src/friendica/proxy; \
+    mkdir -p /usr/src/friendica/addon; \
     tar -xzf friendica_addons.tar.gz -C /usr/src/friendica/addon --strip-components=1; \
     rm friendica_addons.tar.gz; \
     /usr/src/friendica/bin/composer.phar install --no-dev -d /usr/src/friendica;

--- a/2019.04/fpm-alpine/entrypoint.sh
+++ b/2019.04/fpm-alpine/entrypoint.sh
@@ -141,8 +141,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
 			if [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ] && [ -n "${MYSQL_USER+x}" -o -n "${MYSQL_USERNAME+x}" ] && [ -n ${FRIENDICA_ADMIN_MAIL+x} ]; then
 				echo "Installation with environment variables"
 
-				# TODO Bug in PHP Path for automatic installation
-				#FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
+				FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
 				FRIENDICA_TZ=${FRIENDICA_TZ:-America/LosAngeles}
 				FRIENDICA_LANG=${FRIENDICA_LANG:-en}
 				MYSQL_PORT=${MYSQL_PORT:-3306}

--- a/2019.04/fpm-alpine/upgrade.exclude
+++ b/2019.04/fpm-alpine/upgrade.exclude
@@ -9,3 +9,4 @@
 /config/local.config.php
 /config/addon.config.php
 /storage/
+*.log

--- a/2019.04/fpm/Dockerfile
+++ b/2019.04/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:7.1-fpm
+FROM php:7.3-fpm-stretch
 LABEL maintainer="Philipp Holzer <admin@philipp.info>"
 
 # entrypoint.sh and cron.sh dependencies
@@ -34,8 +34,6 @@ RUN set -ex; \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        libmcrypt4 \
-        libmcrypt-dev \
         imagemagick \
         libmagick++-dev \
         libmemcached-dev \
@@ -45,29 +43,43 @@ RUN set -ex; \
         librsvg2-2 \
         libcurl4-openssl-dev \
         curl \
+        libzip-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    pecl install imagick-3.4.3; \
-        docker-php-ext-enable imagick; \
-        pecl clear-cache \
-    ; \
+    \
     docker-php-ext-configure gd \
         --with-gd \
-        --enable-gd-native-ttf \
         --with-freetype-dir=/usr/include/ \
         --with-png-dir=/usr/include/ \
         --with-jpeg-dir=/usr/include/ \
     ; \
-    docker-php-ext-install -j 4 curl pdo pdo_mysql xml gd zip opcache mbstring posix ctype json iconv mcrypt \
+    docker-php-ext-install -j 4 \
+        curl \
+        pdo \
+        pdo_mysql \
+        xml \
+        gd \
+        zip \
+        opcache \
+        mbstring \
+        posix \
+        ctype \
+        json \
+        iconv \
     ; \
+    \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install memcached-3.0.4; \
-    pecl install redis-3.1.6; \
+    pecl install apcu-5.1.17; \
+    pecl install memcached-3.1.3; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \
+        apcu \
         memcached \
         redis \
+        imagick \
     ; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
@@ -84,16 +96,20 @@ RUN set -ex; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 
-RUN chown -R www-data:root /var/www; \
+RUN {\
+      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
+    } > /usr/local/etc/php/conf.d/sendmail.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
 VOLUME /var/www/html
-WORKDIR /var/www/html
 
-
-RUN {\
-      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
-    } > /usr/local/etc/php/conf.d/sendmail.ini;
 
 COPY *.sh upgrade.exclude /
 RUN chmod +x /*.sh
@@ -110,7 +126,8 @@ RUN set -ex; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     curl -fsSL -o friendica_addons.tar.gz \
         "https://github.com/friendica/friendica-addons/archive/${FRIENDICA_ADDONS}.tar.gz"; \
-    mkdir /usr/src/friendica/addon; \
+    mkdir -p /usr/src/friendica/proxy; \
+    mkdir -p /usr/src/friendica/addon; \
     tar -xzf friendica_addons.tar.gz -C /usr/src/friendica/addon --strip-components=1; \
     rm friendica_addons.tar.gz; \
     /usr/src/friendica/bin/composer.phar install --no-dev -d /usr/src/friendica;

--- a/2019.04/fpm/entrypoint.sh
+++ b/2019.04/fpm/entrypoint.sh
@@ -141,8 +141,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
 			if [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ] && [ -n "${MYSQL_USER+x}" -o -n "${MYSQL_USERNAME+x}" ] && [ -n ${FRIENDICA_ADMIN_MAIL+x} ]; then
 				echo "Installation with environment variables"
 
-				# TODO Bug in PHP Path for automatic installation
-				#FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
+				FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
 				FRIENDICA_TZ=${FRIENDICA_TZ:-America/LosAngeles}
 				FRIENDICA_LANG=${FRIENDICA_LANG:-en}
 				MYSQL_PORT=${MYSQL_PORT:-3306}

--- a/2019.04/fpm/upgrade.exclude
+++ b/2019.04/fpm/upgrade.exclude
@@ -9,3 +9,4 @@
 /config/local.config.php
 /config/addon.config.php
 /storage/
+*.log

--- a/2019.06-dev/apache/Dockerfile
+++ b/2019.06-dev/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:7.1-apache
+FROM php:7.3-apache-stretch
 LABEL maintainer="Philipp Holzer <admin@philipp.info>"
 
 # entrypoint.sh and cron.sh dependencies
@@ -34,8 +34,6 @@ RUN set -ex; \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        libmcrypt4 \
-        libmcrypt-dev \
         imagemagick \
         libmagick++-dev \
         libmemcached-dev \
@@ -45,29 +43,43 @@ RUN set -ex; \
         librsvg2-2 \
         libcurl4-openssl-dev \
         curl \
+        libzip-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    pecl install imagick-3.4.3; \
-        docker-php-ext-enable imagick; \
-        pecl clear-cache \
-    ; \
+    \
     docker-php-ext-configure gd \
         --with-gd \
-        --enable-gd-native-ttf \
         --with-freetype-dir=/usr/include/ \
         --with-png-dir=/usr/include/ \
         --with-jpeg-dir=/usr/include/ \
     ; \
-    docker-php-ext-install -j 4 curl pdo pdo_mysql xml gd zip opcache mbstring posix ctype json iconv mcrypt \
+    docker-php-ext-install -j 4 \
+        curl \
+        pdo \
+        pdo_mysql \
+        xml \
+        gd \
+        zip \
+        opcache \
+        mbstring \
+        posix \
+        ctype \
+        json \
+        iconv \
     ; \
+    \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install memcached-3.0.4; \
-    pecl install redis-3.1.6; \
+    pecl install apcu-5.1.17; \
+    pecl install memcached-3.1.3; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \
+        apcu \
         memcached \
         redis \
+        imagick \
     ; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
@@ -84,11 +96,19 @@ RUN set -ex; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 
-RUN chown -R www-data:root /var/www; \
+RUN {\
+      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
+    } > /usr/local/etc/php/conf.d/sendmail.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
 VOLUME /var/www/html
-WORKDIR /var/www/html
 
 RUN a2enmod rewrite remoteip ;\
     {\
@@ -98,10 +118,6 @@ RUN a2enmod rewrite remoteip ;\
      echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
     a2enconf remoteip
-
-RUN {\
-      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
-    } > /usr/local/etc/php/conf.d/sendmail.ini;
 
 COPY *.sh upgrade.exclude /
 RUN chmod +x /*.sh

--- a/2019.06-dev/apache/entrypoint.sh
+++ b/2019.06-dev/apache/entrypoint.sh
@@ -141,8 +141,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
 			if [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ] && [ -n "${MYSQL_USER+x}" -o -n "${MYSQL_USERNAME+x}" ] && [ -n ${FRIENDICA_ADMIN_MAIL+x} ]; then
 				echo "Installation with environment variables"
 
-				# TODO Bug in PHP Path for automatic installation
-				#FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
+				FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
 				FRIENDICA_TZ=${FRIENDICA_TZ:-America/LosAngeles}
 				FRIENDICA_LANG=${FRIENDICA_LANG:-en}
 				MYSQL_PORT=${MYSQL_PORT:-3306}

--- a/2019.06-dev/apache/upgrade.exclude
+++ b/2019.06-dev/apache/upgrade.exclude
@@ -9,3 +9,4 @@
 /config/local.config.php
 /config/addon.config.php
 /storage/
+*.log

--- a/2019.06-dev/fpm-alpine/Dockerfile
+++ b/2019.06-dev/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:7.1-fpm-alpine
+FROM php:7.3-fpm-alpine
 LABEL maintainer="Philipp Holzer <admin@philipp.info>"
 
 # entrypoint.sh and cron.sh dependencies
@@ -29,8 +29,6 @@ RUN set -ex; \
         imagemagick-dev \
         imagemagick \
         libtool \
-        libmcrypt \
-        libmcrypt-dev \
         libmemcached-dev \
         cyrus-sasl-dev \
         freetype \
@@ -44,26 +42,42 @@ RUN set -ex; \
         rsync \
         bzip2 \
         pcre-dev \
+        libzip-dev \
     ; \
-    pecl install imagick-3.4.3; \
-        docker-php-ext-enable imagick; \
-        pecl clear-cache; \
+    \
     docker-php-ext-configure gd \
         --with-gd \
-        --enable-gd-native-ttf \
         --with-freetype-dir=/usr/include/ \
         --with-png-dir=/usr/include/ \
         --with-jpeg-dir=/usr/include/ \
     ; \
-    docker-php-ext-install -j 4 curl pdo pdo_mysql xml gd zip opcache mbstring posix ctype json iconv mcrypt; \
+    \
+    docker-php-ext-install -j 4 \
+       curl \
+       pdo \
+       pdo_mysql \
+       xml \
+       gd \
+       zip \
+       opcache \
+       mbstring \
+       posix \
+       ctype \
+       json \
+       iconv \
+    ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install memcached-3.0.4; \
-    pecl install redis-3.1.6; \
+    pecl install APCu-5.1.17; \
+    pecl install memcached-3.1.3; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \
+    	apcu \
         memcached \
         redis \
+        imagick \
     ; \
     \
     runDeps="$( \
@@ -75,16 +89,20 @@ RUN set -ex; \
     apk add --virtual .friendica-phpext-rundeps $runDeps; \
     apk del .build-deps;
 
-RUN chown -R www-data:www-data /var/www; \
+RUN {\
+        echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
+    } > /usr/local/etc/php/conf.d/sendmail.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
 VOLUME /var/www/html
-WORKDIR /var/www/html
 
-
-RUN {\
-      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
-    } > /usr/local/etc/php/conf.d/sendmail.ini;
 
 COPY *.sh upgrade.exclude /
 RUN chmod +x /*.sh

--- a/2019.06-dev/fpm-alpine/entrypoint.sh
+++ b/2019.06-dev/fpm-alpine/entrypoint.sh
@@ -141,8 +141,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
 			if [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ] && [ -n "${MYSQL_USER+x}" -o -n "${MYSQL_USERNAME+x}" ] && [ -n ${FRIENDICA_ADMIN_MAIL+x} ]; then
 				echo "Installation with environment variables"
 
-				# TODO Bug in PHP Path for automatic installation
-				#FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
+				FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
 				FRIENDICA_TZ=${FRIENDICA_TZ:-America/LosAngeles}
 				FRIENDICA_LANG=${FRIENDICA_LANG:-en}
 				MYSQL_PORT=${MYSQL_PORT:-3306}

--- a/2019.06-dev/fpm-alpine/upgrade.exclude
+++ b/2019.06-dev/fpm-alpine/upgrade.exclude
@@ -9,3 +9,4 @@
 /config/local.config.php
 /config/addon.config.php
 /storage/
+*.log

--- a/2019.06-dev/fpm/Dockerfile
+++ b/2019.06-dev/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:7.1-fpm
+FROM php:7.3-fpm-stretch
 LABEL maintainer="Philipp Holzer <admin@philipp.info>"
 
 # entrypoint.sh and cron.sh dependencies
@@ -34,8 +34,6 @@ RUN set -ex; \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        libmcrypt4 \
-        libmcrypt-dev \
         imagemagick \
         libmagick++-dev \
         libmemcached-dev \
@@ -45,29 +43,43 @@ RUN set -ex; \
         librsvg2-2 \
         libcurl4-openssl-dev \
         curl \
+        libzip-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    pecl install imagick-3.4.3; \
-        docker-php-ext-enable imagick; \
-        pecl clear-cache \
-    ; \
+    \
     docker-php-ext-configure gd \
         --with-gd \
-        --enable-gd-native-ttf \
         --with-freetype-dir=/usr/include/ \
         --with-png-dir=/usr/include/ \
         --with-jpeg-dir=/usr/include/ \
     ; \
-    docker-php-ext-install -j 4 curl pdo pdo_mysql xml gd zip opcache mbstring posix ctype json iconv mcrypt \
+    docker-php-ext-install -j 4 \
+        curl \
+        pdo \
+        pdo_mysql \
+        xml \
+        gd \
+        zip \
+        opcache \
+        mbstring \
+        posix \
+        ctype \
+        json \
+        iconv \
     ; \
+    \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install memcached-3.0.4; \
-    pecl install redis-3.1.6; \
+    pecl install apcu-5.1.17; \
+    pecl install memcached-3.1.3; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \
+        apcu \
         memcached \
         redis \
+        imagick \
     ; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
@@ -84,16 +96,20 @@ RUN set -ex; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 
-RUN chown -R www-data:root /var/www; \
+RUN {\
+      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
+    } > /usr/local/etc/php/conf.d/sendmail.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
 VOLUME /var/www/html
-WORKDIR /var/www/html
 
-
-RUN {\
-      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
-    } > /usr/local/etc/php/conf.d/sendmail.ini;
 
 COPY *.sh upgrade.exclude /
 RUN chmod +x /*.sh

--- a/2019.06-dev/fpm/entrypoint.sh
+++ b/2019.06-dev/fpm/entrypoint.sh
@@ -141,8 +141,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
 			if [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ] && [ -n "${MYSQL_USER+x}" -o -n "${MYSQL_USERNAME+x}" ] && [ -n ${FRIENDICA_ADMIN_MAIL+x} ]; then
 				echo "Installation with environment variables"
 
-				# TODO Bug in PHP Path for automatic installation
-				#FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
+				FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
 				FRIENDICA_TZ=${FRIENDICA_TZ:-America/LosAngeles}
 				FRIENDICA_LANG=${FRIENDICA_LANG:-en}
 				MYSQL_PORT=${MYSQL_PORT:-3306}

--- a/2019.06-dev/fpm/upgrade.exclude
+++ b/2019.06-dev/fpm/upgrade.exclude
@@ -9,3 +9,4 @@
 /config/local.config.php
 /config/addon.config.php
 /storage/
+*.log

--- a/2019.06-rc/apache/Dockerfile
+++ b/2019.06-rc/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:7.1-apache
+FROM php:7.3-apache-stretch
 LABEL maintainer="Philipp Holzer <admin@philipp.info>"
 
 # entrypoint.sh and cron.sh dependencies
@@ -34,8 +34,6 @@ RUN set -ex; \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        libmcrypt4 \
-        libmcrypt-dev \
         imagemagick \
         libmagick++-dev \
         libmemcached-dev \
@@ -45,29 +43,43 @@ RUN set -ex; \
         librsvg2-2 \
         libcurl4-openssl-dev \
         curl \
+        libzip-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    pecl install imagick-3.4.3; \
-        docker-php-ext-enable imagick; \
-        pecl clear-cache \
-    ; \
+    \
     docker-php-ext-configure gd \
         --with-gd \
-        --enable-gd-native-ttf \
         --with-freetype-dir=/usr/include/ \
         --with-png-dir=/usr/include/ \
         --with-jpeg-dir=/usr/include/ \
     ; \
-    docker-php-ext-install -j 4 curl pdo pdo_mysql xml gd zip opcache mbstring posix ctype json iconv mcrypt \
+    docker-php-ext-install -j 4 \
+        curl \
+        pdo \
+        pdo_mysql \
+        xml \
+        gd \
+        zip \
+        opcache \
+        mbstring \
+        posix \
+        ctype \
+        json \
+        iconv \
     ; \
+    \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install memcached-3.0.4; \
-    pecl install redis-3.1.6; \
+    pecl install apcu-5.1.17; \
+    pecl install memcached-3.1.3; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \
+        apcu \
         memcached \
         redis \
+        imagick \
     ; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
@@ -84,11 +96,19 @@ RUN set -ex; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 
-RUN chown -R www-data:root /var/www; \
+RUN {\
+      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
+    } > /usr/local/etc/php/conf.d/sendmail.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
 VOLUME /var/www/html
-WORKDIR /var/www/html
 
 RUN a2enmod rewrite remoteip ;\
     {\
@@ -98,10 +118,6 @@ RUN a2enmod rewrite remoteip ;\
      echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
     a2enconf remoteip
-
-RUN {\
-      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
-    } > /usr/local/etc/php/conf.d/sendmail.ini;
 
 COPY *.sh upgrade.exclude /
 RUN chmod +x /*.sh

--- a/2019.06-rc/apache/entrypoint.sh
+++ b/2019.06-rc/apache/entrypoint.sh
@@ -141,8 +141,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
 			if [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ] && [ -n "${MYSQL_USER+x}" -o -n "${MYSQL_USERNAME+x}" ] && [ -n ${FRIENDICA_ADMIN_MAIL+x} ]; then
 				echo "Installation with environment variables"
 
-				# TODO Bug in PHP Path for automatic installation
-				#FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
+				FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
 				FRIENDICA_TZ=${FRIENDICA_TZ:-America/LosAngeles}
 				FRIENDICA_LANG=${FRIENDICA_LANG:-en}
 				MYSQL_PORT=${MYSQL_PORT:-3306}

--- a/2019.06-rc/apache/upgrade.exclude
+++ b/2019.06-rc/apache/upgrade.exclude
@@ -9,3 +9,4 @@
 /config/local.config.php
 /config/addon.config.php
 /storage/
+*.log

--- a/2019.06-rc/fpm-alpine/Dockerfile
+++ b/2019.06-rc/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:7.1-fpm-alpine
+FROM php:7.3-fpm-alpine
 LABEL maintainer="Philipp Holzer <admin@philipp.info>"
 
 # entrypoint.sh and cron.sh dependencies
@@ -29,8 +29,6 @@ RUN set -ex; \
         imagemagick-dev \
         imagemagick \
         libtool \
-        libmcrypt \
-        libmcrypt-dev \
         libmemcached-dev \
         cyrus-sasl-dev \
         freetype \
@@ -44,26 +42,42 @@ RUN set -ex; \
         rsync \
         bzip2 \
         pcre-dev \
+        libzip-dev \
     ; \
-    pecl install imagick-3.4.3; \
-        docker-php-ext-enable imagick; \
-        pecl clear-cache; \
+    \
     docker-php-ext-configure gd \
         --with-gd \
-        --enable-gd-native-ttf \
         --with-freetype-dir=/usr/include/ \
         --with-png-dir=/usr/include/ \
         --with-jpeg-dir=/usr/include/ \
     ; \
-    docker-php-ext-install -j 4 curl pdo pdo_mysql xml gd zip opcache mbstring posix ctype json iconv mcrypt; \
+    \
+    docker-php-ext-install -j 4 \
+       curl \
+       pdo \
+       pdo_mysql \
+       xml \
+       gd \
+       zip \
+       opcache \
+       mbstring \
+       posix \
+       ctype \
+       json \
+       iconv \
+    ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install memcached-3.0.4; \
-    pecl install redis-3.1.6; \
+    pecl install APCu-5.1.17; \
+    pecl install memcached-3.1.3; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \
+    	apcu \
         memcached \
         redis \
+        imagick \
     ; \
     \
     runDeps="$( \
@@ -75,16 +89,20 @@ RUN set -ex; \
     apk add --virtual .friendica-phpext-rundeps $runDeps; \
     apk del .build-deps;
 
-RUN chown -R www-data:www-data /var/www; \
+RUN {\
+        echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
+    } > /usr/local/etc/php/conf.d/sendmail.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
 VOLUME /var/www/html
-WORKDIR /var/www/html
 
-
-RUN {\
-      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
-    } > /usr/local/etc/php/conf.d/sendmail.ini;
 
 COPY *.sh upgrade.exclude /
 RUN chmod +x /*.sh

--- a/2019.06-rc/fpm-alpine/entrypoint.sh
+++ b/2019.06-rc/fpm-alpine/entrypoint.sh
@@ -141,8 +141,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
 			if [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ] && [ -n "${MYSQL_USER+x}" -o -n "${MYSQL_USERNAME+x}" ] && [ -n ${FRIENDICA_ADMIN_MAIL+x} ]; then
 				echo "Installation with environment variables"
 
-				# TODO Bug in PHP Path for automatic installation
-				#FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
+				FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
 				FRIENDICA_TZ=${FRIENDICA_TZ:-America/LosAngeles}
 				FRIENDICA_LANG=${FRIENDICA_LANG:-en}
 				MYSQL_PORT=${MYSQL_PORT:-3306}

--- a/2019.06-rc/fpm-alpine/upgrade.exclude
+++ b/2019.06-rc/fpm-alpine/upgrade.exclude
@@ -9,3 +9,4 @@
 /config/local.config.php
 /config/addon.config.php
 /storage/
+*.log

--- a/2019.06-rc/fpm/Dockerfile
+++ b/2019.06-rc/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:7.1-fpm
+FROM php:7.3-fpm-stretch
 LABEL maintainer="Philipp Holzer <admin@philipp.info>"
 
 # entrypoint.sh and cron.sh dependencies
@@ -34,8 +34,6 @@ RUN set -ex; \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        libmcrypt4 \
-        libmcrypt-dev \
         imagemagick \
         libmagick++-dev \
         libmemcached-dev \
@@ -45,29 +43,43 @@ RUN set -ex; \
         librsvg2-2 \
         libcurl4-openssl-dev \
         curl \
+        libzip-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    pecl install imagick-3.4.3; \
-        docker-php-ext-enable imagick; \
-        pecl clear-cache \
-    ; \
+    \
     docker-php-ext-configure gd \
         --with-gd \
-        --enable-gd-native-ttf \
         --with-freetype-dir=/usr/include/ \
         --with-png-dir=/usr/include/ \
         --with-jpeg-dir=/usr/include/ \
     ; \
-    docker-php-ext-install -j 4 curl pdo pdo_mysql xml gd zip opcache mbstring posix ctype json iconv mcrypt \
+    docker-php-ext-install -j 4 \
+        curl \
+        pdo \
+        pdo_mysql \
+        xml \
+        gd \
+        zip \
+        opcache \
+        mbstring \
+        posix \
+        ctype \
+        json \
+        iconv \
     ; \
+    \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install memcached-3.0.4; \
-    pecl install redis-3.1.6; \
+    pecl install apcu-5.1.17; \
+    pecl install memcached-3.1.3; \
+    pecl install redis-4.3.0; \
+    pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \
+        apcu \
         memcached \
         redis \
+        imagick \
     ; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
@@ -84,16 +96,20 @@ RUN set -ex; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 
-RUN chown -R www-data:root /var/www; \
+RUN {\
+      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
+    } > /usr/local/etc/php/conf.d/sendmail.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
 VOLUME /var/www/html
-WORKDIR /var/www/html
 
-
-RUN {\
-      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
-    } > /usr/local/etc/php/conf.d/sendmail.ini;
 
 COPY *.sh upgrade.exclude /
 RUN chmod +x /*.sh

--- a/2019.06-rc/fpm/entrypoint.sh
+++ b/2019.06-rc/fpm/entrypoint.sh
@@ -141,8 +141,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
 			if [ -n "${MYSQL_DATABASE+x}" ] && [ -n "${MYSQL_PASSWORD+x}" ] && [ -n "${MYSQL_HOST+x}" ] && [ -n "${MYSQL_USER+x}" -o -n "${MYSQL_USERNAME+x}" ] && [ -n ${FRIENDICA_ADMIN_MAIL+x} ]; then
 				echo "Installation with environment variables"
 
-				# TODO Bug in PHP Path for automatic installation
-				#FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
+				FRIENDICA_PHP_PATH=${FRIENDICA_PHP_PATH:-/usr/local/php}
 				FRIENDICA_TZ=${FRIENDICA_TZ:-America/LosAngeles}
 				FRIENDICA_LANG=${FRIENDICA_LANG:-en}
 				MYSQL_PORT=${MYSQL_PORT:-3306}

--- a/2019.06-rc/fpm/upgrade.exclude
+++ b/2019.06-rc/fpm/upgrade.exclude
@@ -9,3 +9,4 @@
 /config/local.config.php
 /config/addon.config.php
 /storage/
+*.log

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -28,8 +28,6 @@ RUN set -ex; \
         imagemagick-dev \
         imagemagick \
         libtool \
-        libmcrypt \
-        libmcrypt-dev \
         libmemcached-dev \
         cyrus-sasl-dev \
         freetype \
@@ -43,26 +41,42 @@ RUN set -ex; \
         rsync \
         bzip2 \
         pcre-dev \
+        libzip-dev \
     ; \
-    pecl install imagick-%%IMAGICK_VERSION%%; \
-        docker-php-ext-enable imagick; \
-        pecl clear-cache; \
+    \
     docker-php-ext-configure gd \
         --with-gd \
-        --enable-gd-native-ttf \
         --with-freetype-dir=/usr/include/ \
         --with-png-dir=/usr/include/ \
         --with-jpeg-dir=/usr/include/ \
     ; \
-    docker-php-ext-install -j 4 curl pdo pdo_mysql xml gd zip opcache mbstring posix ctype json iconv mcrypt; \
+    \
+    docker-php-ext-install -j 4 \
+       curl \
+       pdo \
+       pdo_mysql \
+       xml \
+       gd \
+       zip \
+       opcache \
+       mbstring \
+       posix \
+       ctype \
+       json \
+       iconv \
+    ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-%%APCU_VERSION%%; \
     pecl install memcached-%%MEMCACHED_VERSION%%; \
     pecl install redis-%%REDIS_VERSION%%; \
+    pecl install imagick-%%IMAGICK_VERSION%%; \
     \
     docker-php-ext-enable \
+    	apcu \
         memcached \
         redis \
+        imagick \
     ; \
     \
     runDeps="$( \
@@ -74,16 +88,20 @@ RUN set -ex; \
     apk add --virtual .friendica-phpext-rundeps $runDeps; \
     apk del .build-deps;
 
-RUN chown -R www-data:www-data /var/www; \
+RUN {\
+        echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
+    } > /usr/local/etc/php/conf.d/sendmail.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
 VOLUME /var/www/html
-WORKDIR /var/www/html
 %%VARIANT_EXTRAS%%
-
-RUN {\
-      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
-    } > /usr/local/etc/php/conf.d/sendmail.ini;
 
 COPY *.sh upgrade.exclude /
 RUN chmod +x /*.sh

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,4 +1,4 @@
-FROM php:%%PHP_VERSION%%-%%VARIANT%%
+FROM php:%%PHP_VERSION%%-%%VARIANT%%-stretch
 LABEL maintainer="Philipp Holzer <admin@philipp.info>"
 
 # entrypoint.sh and cron.sh dependencies
@@ -33,8 +33,6 @@ RUN set -ex; \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        libmcrypt4 \
-        libmcrypt-dev \
         imagemagick \
         libmagick++-dev \
         libmemcached-dev \
@@ -44,29 +42,43 @@ RUN set -ex; \
         librsvg2-2 \
         libcurl4-openssl-dev \
         curl \
+        libzip-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    pecl install imagick-%%IMAGICK_VERSION%%; \
-        docker-php-ext-enable imagick; \
-        pecl clear-cache \
-    ; \
+    \
     docker-php-ext-configure gd \
         --with-gd \
-        --enable-gd-native-ttf \
         --with-freetype-dir=/usr/include/ \
         --with-png-dir=/usr/include/ \
         --with-jpeg-dir=/usr/include/ \
     ; \
-    docker-php-ext-install -j 4 curl pdo pdo_mysql xml gd zip opcache mbstring posix ctype json iconv mcrypt \
+    docker-php-ext-install -j 4 \
+        curl \
+        pdo \
+        pdo_mysql \
+        xml \
+        gd \
+        zip \
+        opcache \
+        mbstring \
+        posix \
+        ctype \
+        json \
+        iconv \
     ; \
+    \
 # pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install apcu-%%APCU_VERSION%%; \
     pecl install memcached-%%MEMCACHED_VERSION%%; \
     pecl install redis-%%REDIS_VERSION%%; \
+    pecl install imagick-%%IMAGICK_VERSION%%; \
     \
     docker-php-ext-enable \
+        apcu \
         memcached \
         redis \
+        imagick \
     ; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
@@ -83,16 +95,20 @@ RUN set -ex; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 
-RUN chown -R www-data:root /var/www; \
+RUN {\
+      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
+    } > /usr/local/etc/php/conf.d/sendmail.ini; \
+    \
+    echo 'apc.enable_cli=1' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini; \
+    \
+    echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/memory-limit.ini; \
+    \
+    mkdir /var/www/data; \
+    chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
 VOLUME /var/www/html
-WORKDIR /var/www/html
 %%VARIANT_EXTRAS%%
-
-RUN {\
-      echo sendmail_path = "/usr/sbin/sendmail -t -i" ;\
-    } > /usr/local/etc/php/conf.d/sendmail.ini;
 
 COPY *.sh upgrade.exclude /
 RUN chmod +x /*.sh


### PR DESCRIPTION
- Adding APCu
- Bump PHP to 7.3
- Remove deprecated mcrypt
- Dynamic version checking for depending PECL libraries
- Add production default 512M for memory_limit (see https://github.com/friendica/docker/issues/56)
- Re-Add FRIENDICA_PHP_PATH because of Bugfix in upstream