### PR TITLE
Fix pcntl_fork error

### DIFF
--- a/2019.06/apache/Dockerfile
+++ b/2019.06/apache/Dockerfile
@@ -67,12 +67,13 @@ RUN set -ex; \
         ctype \
         json \
         iconv \
+        pcntl \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install apcu-5.1.17; \
     pecl install memcached-3.1.3; \
-    pecl install redis-5.0.1; \
+    pecl install redis-5.0.2; \
     pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \

--- a/2019.06/fpm-alpine/Dockerfile
+++ b/2019.06/fpm-alpine/Dockerfile
@@ -65,12 +65,13 @@ RUN set -ex; \
        ctype \
        json \
        iconv \
+       pcntl \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install APCu-5.1.17; \
     pecl install memcached-3.1.3; \
-    pecl install redis-5.0.1; \
+    pecl install redis-5.0.2; \
     pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \

--- a/2019.06/fpm/Dockerfile
+++ b/2019.06/fpm/Dockerfile
@@ -67,12 +67,13 @@ RUN set -ex; \
         ctype \
         json \
         iconv \
+        pcntl \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install apcu-5.1.17; \
     pecl install memcached-3.1.3; \
-    pecl install redis-5.0.1; \
+    pecl install redis-5.0.2; \
     pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \

--- a/2019.09-dev/apache/Dockerfile
+++ b/2019.09-dev/apache/Dockerfile
@@ -67,12 +67,13 @@ RUN set -ex; \
         ctype \
         json \
         iconv \
+        pcntl \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install apcu-5.1.17; \
     pecl install memcached-3.1.3; \
-    pecl install redis-5.0.1; \
+    pecl install redis-5.0.2; \
     pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \

--- a/2019.09-dev/fpm-alpine/Dockerfile
+++ b/2019.09-dev/fpm-alpine/Dockerfile
@@ -65,12 +65,13 @@ RUN set -ex; \
        ctype \
        json \
        iconv \
+       pcntl \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install APCu-5.1.17; \
     pecl install memcached-3.1.3; \
-    pecl install redis-5.0.1; \
+    pecl install redis-5.0.2; \
     pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \

--- a/2019.09-dev/fpm/Dockerfile
+++ b/2019.09-dev/fpm/Dockerfile
@@ -67,12 +67,13 @@ RUN set -ex; \
         ctype \
         json \
         iconv \
+        pcntl \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install apcu-5.1.17; \
     pecl install memcached-3.1.3; \
-    pecl install redis-5.0.1; \
+    pecl install redis-5.0.2; \
     pecl install imagick-3.4.4; \
     \
     docker-php-ext-enable \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -64,6 +64,7 @@ RUN set -ex; \
        ctype \
        json \
        iconv \
+       pcntl \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -66,6 +66,7 @@ RUN set -ex; \
         ctype \
         json \
         iconv \
+        pcntl \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately


### PR DESCRIPTION
Fixes #72 
@MrPetovan we can think about adding `ext-pcntl` to the composer as well, since without it, the daemon is unusable.