### PR TITLE
docker-77 Deduplicate dependencies

### DIFF
--- a/2019.06/apache/Dockerfile
+++ b/2019.06/apache/Dockerfile
@@ -51,14 +51,12 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        curl \
         pdo \
         pdo_mysql \
         xml \
         gd \
         zip \
         opcache \
-        mbstring \
         posix \
         ctype \
         json \

--- a/2019.06/apache/Dockerfile
+++ b/2019.06/apache/Dockerfile
@@ -22,14 +22,11 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        libxml2-dev \
         mysql-client \
         bash \
         autoconf \
         g++ \
         make \
-        openssl \
-        libssl-dev \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
@@ -40,8 +37,6 @@ RUN set -ex; \
         libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
-        libcurl4-openssl-dev \
-        curl \
         libzip-dev \
     ; \
     docker-php-ext-configure gd \
@@ -51,16 +46,11 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        pdo \
         pdo_mysql \
-        xml \
         gd \
         zip \
         opcache \
-        posix \
         ctype \
-        json \
-        iconv \
         pcntl \
     ; \
     \

--- a/2019.06/apache/Dockerfile
+++ b/2019.06/apache/Dockerfile
@@ -24,17 +24,13 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends \
         mysql-client \
         bash \
-        autoconf \
-        g++ \
-        make \
+        $PHPIZE_DEPS \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        imagemagick \
         libmagick++-dev \
         libmemcached-dev \
         libgraphicsmagick1-dev \
-        libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
         libzip-dev \

--- a/2019.06/fpm-alpine/Dockerfile
+++ b/2019.06/fpm-alpine/Dockerfile
@@ -52,14 +52,12 @@ RUN set -ex; \
     ; \
     \
     docker-php-ext-install -j "$(nproc)" \
-       curl \
        pdo \
        pdo_mysql \
        xml \
        gd \
        zip \
        opcache \
-       mbstring \
        posix \
        ctype \
        json \

--- a/2019.06/fpm-alpine/Dockerfile
+++ b/2019.06/fpm-alpine/Dockerfile
@@ -14,14 +14,11 @@ RUN set -ex; \
 RUN set -ex; \
     \
     apk add -U --no-cache --virtual .build-deps \
-        libxml2-dev \
         mysql-client \
         bash \
         autoconf \
         g++ \
         make \
-        openssl \
-        openssl-dev \
         libpng \
         libpng-dev \
         libjpeg-turbo-dev \
@@ -36,8 +33,6 @@ RUN set -ex; \
         freetype-dev \
         librsvg \
         libcurl \
-        curl \
-        curl-dev \
         rsync \
         bzip2 \
         pcre-dev \
@@ -52,16 +47,10 @@ RUN set -ex; \
     ; \
     \
     docker-php-ext-install -j "$(nproc)" \
-       pdo \
        pdo_mysql \
-       xml \
        gd \
        zip \
        opcache \
-       posix \
-       ctype \
-       json \
-       iconv \
        pcntl \
     ; \
     \

--- a/2019.06/fpm-alpine/Dockerfile
+++ b/2019.06/fpm-alpine/Dockerfile
@@ -16,25 +16,16 @@ RUN set -ex; \
     apk add -U --no-cache --virtual .build-deps \
         mysql-client \
         bash \
-        autoconf \
-        g++ \
-        make \
-        libpng \
+        $PHPIZE_DEPS \
         libpng-dev \
         libjpeg-turbo-dev \
         imagemagick-dev \
-        imagemagick \
         libtool \
         libmemcached-dev \
         cyrus-sasl-dev \
-        freetype \
-        libpng \
         libjpeg-turbo-dev \
         freetype-dev \
         librsvg \
-        libcurl \
-        rsync \
-        bzip2 \
         pcre-dev \
         libzip-dev \
     ; \

--- a/2019.06/fpm/Dockerfile
+++ b/2019.06/fpm/Dockerfile
@@ -51,14 +51,12 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        curl \
         pdo \
         pdo_mysql \
         xml \
         gd \
         zip \
         opcache \
-        mbstring \
         posix \
         ctype \
         json \

--- a/2019.06/fpm/Dockerfile
+++ b/2019.06/fpm/Dockerfile
@@ -22,14 +22,11 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        libxml2-dev \
         mysql-client \
         bash \
         autoconf \
         g++ \
         make \
-        openssl \
-        libssl-dev \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
@@ -40,8 +37,6 @@ RUN set -ex; \
         libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
-        libcurl4-openssl-dev \
-        curl \
         libzip-dev \
     ; \
     docker-php-ext-configure gd \
@@ -51,16 +46,11 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        pdo \
         pdo_mysql \
-        xml \
         gd \
         zip \
         opcache \
-        posix \
         ctype \
-        json \
-        iconv \
         pcntl \
     ; \
     \

--- a/2019.06/fpm/Dockerfile
+++ b/2019.06/fpm/Dockerfile
@@ -24,17 +24,13 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends \
         mysql-client \
         bash \
-        autoconf \
-        g++ \
-        make \
+        $PHPIZE_DEPS \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        imagemagick \
         libmagick++-dev \
         libmemcached-dev \
         libgraphicsmagick1-dev \
-        libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
         libzip-dev \

--- a/2019.09-dev/apache/Dockerfile
+++ b/2019.09-dev/apache/Dockerfile
@@ -51,14 +51,12 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        curl \
         pdo \
         pdo_mysql \
         xml \
         gd \
         zip \
         opcache \
-        mbstring \
         posix \
         ctype \
         json \

--- a/2019.09-dev/apache/Dockerfile
+++ b/2019.09-dev/apache/Dockerfile
@@ -22,14 +22,11 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        libxml2-dev \
         mysql-client \
         bash \
         autoconf \
         g++ \
         make \
-        openssl \
-        libssl-dev \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
@@ -40,8 +37,6 @@ RUN set -ex; \
         libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
-        libcurl4-openssl-dev \
-        curl \
         libzip-dev \
     ; \
     docker-php-ext-configure gd \
@@ -51,16 +46,11 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        pdo \
         pdo_mysql \
-        xml \
         gd \
         zip \
         opcache \
-        posix \
         ctype \
-        json \
-        iconv \
         pcntl \
     ; \
     \

--- a/2019.09-dev/apache/Dockerfile
+++ b/2019.09-dev/apache/Dockerfile
@@ -24,17 +24,13 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends \
         mysql-client \
         bash \
-        autoconf \
-        g++ \
-        make \
+        $PHPIZE_DEPS \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        imagemagick \
         libmagick++-dev \
         libmemcached-dev \
         libgraphicsmagick1-dev \
-        libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
         libzip-dev \

--- a/2019.09-dev/fpm-alpine/Dockerfile
+++ b/2019.09-dev/fpm-alpine/Dockerfile
@@ -52,14 +52,12 @@ RUN set -ex; \
     ; \
     \
     docker-php-ext-install -j "$(nproc)" \
-       curl \
        pdo \
        pdo_mysql \
        xml \
        gd \
        zip \
        opcache \
-       mbstring \
        posix \
        ctype \
        json \

--- a/2019.09-dev/fpm-alpine/Dockerfile
+++ b/2019.09-dev/fpm-alpine/Dockerfile
@@ -14,14 +14,11 @@ RUN set -ex; \
 RUN set -ex; \
     \
     apk add -U --no-cache --virtual .build-deps \
-        libxml2-dev \
         mysql-client \
         bash \
         autoconf \
         g++ \
         make \
-        openssl \
-        openssl-dev \
         libpng \
         libpng-dev \
         libjpeg-turbo-dev \
@@ -36,8 +33,6 @@ RUN set -ex; \
         freetype-dev \
         librsvg \
         libcurl \
-        curl \
-        curl-dev \
         rsync \
         bzip2 \
         pcre-dev \
@@ -52,16 +47,10 @@ RUN set -ex; \
     ; \
     \
     docker-php-ext-install -j "$(nproc)" \
-       pdo \
        pdo_mysql \
-       xml \
        gd \
        zip \
        opcache \
-       posix \
-       ctype \
-       json \
-       iconv \
        pcntl \
     ; \
     \

--- a/2019.09-dev/fpm-alpine/Dockerfile
+++ b/2019.09-dev/fpm-alpine/Dockerfile
@@ -16,25 +16,16 @@ RUN set -ex; \
     apk add -U --no-cache --virtual .build-deps \
         mysql-client \
         bash \
-        autoconf \
-        g++ \
-        make \
-        libpng \
+        $PHPIZE_DEPS \
         libpng-dev \
         libjpeg-turbo-dev \
         imagemagick-dev \
-        imagemagick \
         libtool \
         libmemcached-dev \
         cyrus-sasl-dev \
-        freetype \
-        libpng \
         libjpeg-turbo-dev \
         freetype-dev \
         librsvg \
-        libcurl \
-        rsync \
-        bzip2 \
         pcre-dev \
         libzip-dev \
     ; \

--- a/2019.09-dev/fpm/Dockerfile
+++ b/2019.09-dev/fpm/Dockerfile
@@ -51,14 +51,12 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        curl \
         pdo \
         pdo_mysql \
         xml \
         gd \
         zip \
         opcache \
-        mbstring \
         posix \
         ctype \
         json \

--- a/2019.09-dev/fpm/Dockerfile
+++ b/2019.09-dev/fpm/Dockerfile
@@ -22,14 +22,11 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        libxml2-dev \
         mysql-client \
         bash \
         autoconf \
         g++ \
         make \
-        openssl \
-        libssl-dev \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
@@ -40,8 +37,6 @@ RUN set -ex; \
         libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
-        libcurl4-openssl-dev \
-        curl \
         libzip-dev \
     ; \
     docker-php-ext-configure gd \
@@ -51,16 +46,11 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        pdo \
         pdo_mysql \
-        xml \
         gd \
         zip \
         opcache \
-        posix \
         ctype \
-        json \
-        iconv \
         pcntl \
     ; \
     \

--- a/2019.09-dev/fpm/Dockerfile
+++ b/2019.09-dev/fpm/Dockerfile
@@ -24,17 +24,13 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends \
         mysql-client \
         bash \
-        autoconf \
-        g++ \
-        make \
+        $PHPIZE_DEPS \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        imagemagick \
         libmagick++-dev \
         libmemcached-dev \
         libgraphicsmagick1-dev \
-        libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
         libzip-dev \

--- a/2019.09-rc/apache/Dockerfile
+++ b/2019.09-rc/apache/Dockerfile
@@ -51,14 +51,12 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        curl \
         pdo \
         pdo_mysql \
         xml \
         gd \
         zip \
         opcache \
-        mbstring \
         posix \
         ctype \
         json \

--- a/2019.09-rc/apache/Dockerfile
+++ b/2019.09-rc/apache/Dockerfile
@@ -22,14 +22,11 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        libxml2-dev \
         mysql-client \
         bash \
         autoconf \
         g++ \
         make \
-        openssl \
-        libssl-dev \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
@@ -40,8 +37,6 @@ RUN set -ex; \
         libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
-        libcurl4-openssl-dev \
-        curl \
         libzip-dev \
     ; \
     docker-php-ext-configure gd \
@@ -51,16 +46,11 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        pdo \
         pdo_mysql \
-        xml \
         gd \
         zip \
         opcache \
-        posix \
         ctype \
-        json \
-        iconv \
         pcntl \
     ; \
     \

--- a/2019.09-rc/apache/Dockerfile
+++ b/2019.09-rc/apache/Dockerfile
@@ -24,17 +24,13 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends \
         mysql-client \
         bash \
-        autoconf \
-        g++ \
-        make \
+        $PHPIZE_DEPS \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        imagemagick \
         libmagick++-dev \
         libmemcached-dev \
         libgraphicsmagick1-dev \
-        libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
         libzip-dev \

--- a/2019.09-rc/fpm-alpine/Dockerfile
+++ b/2019.09-rc/fpm-alpine/Dockerfile
@@ -52,14 +52,12 @@ RUN set -ex; \
     ; \
     \
     docker-php-ext-install -j "$(nproc)" \
-       curl \
        pdo \
        pdo_mysql \
        xml \
        gd \
        zip \
        opcache \
-       mbstring \
        posix \
        ctype \
        json \

--- a/2019.09-rc/fpm-alpine/Dockerfile
+++ b/2019.09-rc/fpm-alpine/Dockerfile
@@ -14,14 +14,11 @@ RUN set -ex; \
 RUN set -ex; \
     \
     apk add -U --no-cache --virtual .build-deps \
-        libxml2-dev \
         mysql-client \
         bash \
         autoconf \
         g++ \
         make \
-        openssl \
-        openssl-dev \
         libpng \
         libpng-dev \
         libjpeg-turbo-dev \
@@ -36,8 +33,6 @@ RUN set -ex; \
         freetype-dev \
         librsvg \
         libcurl \
-        curl \
-        curl-dev \
         rsync \
         bzip2 \
         pcre-dev \
@@ -52,16 +47,10 @@ RUN set -ex; \
     ; \
     \
     docker-php-ext-install -j "$(nproc)" \
-       pdo \
        pdo_mysql \
-       xml \
        gd \
        zip \
        opcache \
-       posix \
-       ctype \
-       json \
-       iconv \
        pcntl \
     ; \
     \

--- a/2019.09-rc/fpm-alpine/Dockerfile
+++ b/2019.09-rc/fpm-alpine/Dockerfile
@@ -16,25 +16,16 @@ RUN set -ex; \
     apk add -U --no-cache --virtual .build-deps \
         mysql-client \
         bash \
-        autoconf \
-        g++ \
-        make \
-        libpng \
+        $PHPIZE_DEPS \
         libpng-dev \
         libjpeg-turbo-dev \
         imagemagick-dev \
-        imagemagick \
         libtool \
         libmemcached-dev \
         cyrus-sasl-dev \
-        freetype \
-        libpng \
         libjpeg-turbo-dev \
         freetype-dev \
         librsvg \
-        libcurl \
-        rsync \
-        bzip2 \
         pcre-dev \
         libzip-dev \
     ; \

--- a/2019.09-rc/fpm/Dockerfile
+++ b/2019.09-rc/fpm/Dockerfile
@@ -51,14 +51,12 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        curl \
         pdo \
         pdo_mysql \
         xml \
         gd \
         zip \
         opcache \
-        mbstring \
         posix \
         ctype \
         json \

--- a/2019.09-rc/fpm/Dockerfile
+++ b/2019.09-rc/fpm/Dockerfile
@@ -22,14 +22,11 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        libxml2-dev \
         mysql-client \
         bash \
         autoconf \
         g++ \
         make \
-        openssl \
-        libssl-dev \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
@@ -40,8 +37,6 @@ RUN set -ex; \
         libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
-        libcurl4-openssl-dev \
-        curl \
         libzip-dev \
     ; \
     docker-php-ext-configure gd \
@@ -51,16 +46,11 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        pdo \
         pdo_mysql \
-        xml \
         gd \
         zip \
         opcache \
-        posix \
         ctype \
-        json \
-        iconv \
         pcntl \
     ; \
     \

--- a/2019.09-rc/fpm/Dockerfile
+++ b/2019.09-rc/fpm/Dockerfile
@@ -24,17 +24,13 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends \
         mysql-client \
         bash \
-        autoconf \
-        g++ \
-        make \
+        $PHPIZE_DEPS \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        imagemagick \
         libmagick++-dev \
         libmemcached-dev \
         libgraphicsmagick1-dev \
-        libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
         libzip-dev \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -51,14 +51,12 @@ RUN set -ex; \
     ; \
     \
     docker-php-ext-install -j "$(nproc)" \
-       curl \
        pdo \
        pdo_mysql \
        xml \
        gd \
        zip \
        opcache \
-       mbstring \
        posix \
        ctype \
        json \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -15,25 +15,16 @@ RUN set -ex; \
     apk add -U --no-cache --virtual .build-deps \
         mysql-client \
         bash \
-        autoconf \
-        g++ \
-        make \
-        libpng \
+        $PHPIZE_DEPS \
         libpng-dev \
         libjpeg-turbo-dev \
         imagemagick-dev \
-        imagemagick \
         libtool \
         libmemcached-dev \
         cyrus-sasl-dev \
-        freetype \
-        libpng \
         libjpeg-turbo-dev \
         freetype-dev \
         librsvg \
-        libcurl \
-        rsync \
-        bzip2 \
         pcre-dev \
         libzip-dev \
     ; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -13,14 +13,11 @@ RUN set -ex; \
 RUN set -ex; \
     \
     apk add -U --no-cache --virtual .build-deps \
-        libxml2-dev \
         mysql-client \
         bash \
         autoconf \
         g++ \
         make \
-        openssl \
-        openssl-dev \
         libpng \
         libpng-dev \
         libjpeg-turbo-dev \
@@ -35,8 +32,6 @@ RUN set -ex; \
         freetype-dev \
         librsvg \
         libcurl \
-        curl \
-        curl-dev \
         rsync \
         bzip2 \
         pcre-dev \
@@ -51,16 +46,10 @@ RUN set -ex; \
     ; \
     \
     docker-php-ext-install -j "$(nproc)" \
-       pdo \
        pdo_mysql \
-       xml \
        gd \
        zip \
        opcache \
-       posix \
-       ctype \
-       json \
-       iconv \
        pcntl \
     ; \
     \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -23,17 +23,13 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends \
         mysql-client \
         bash \
-        autoconf \
-        g++ \
-        make \
+        $PHPIZE_DEPS \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
-        imagemagick \
         libmagick++-dev \
         libmemcached-dev \
         libgraphicsmagick1-dev \
-        libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
         libzip-dev \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -21,14 +21,11 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        libxml2-dev \
         mysql-client \
         bash \
         autoconf \
         g++ \
         make \
-        openssl \
-        libssl-dev \
         libpng-dev \
         libjpeg62-turbo-dev \
         libtool \
@@ -39,8 +36,6 @@ RUN set -ex; \
         libfreetype6 \
         libfreetype6-dev \
         librsvg2-2 \
-        libcurl4-openssl-dev \
-        curl \
         libzip-dev \
     ; \
     docker-php-ext-configure gd \
@@ -50,16 +45,11 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        pdo \
         pdo_mysql \
-        xml \
         gd \
         zip \
         opcache \
-        posix \
         ctype \
-        json \
-        iconv \
         pcntl \
     ; \
     \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -50,14 +50,12 @@ RUN set -ex; \
         --with-jpeg-dir=/usr/include/ \
     ; \
     docker-php-ext-install -j "$(nproc)" \
-        curl \
         pdo \
         pdo_mysql \
         xml \
         gd \
         zip \
         opcache \
-        mbstring \
         posix \
         ctype \
         json \


### PR DESCRIPTION
- remove curl
- remove mbstring

Fixes #77 

@j0wi I checked the Dockerfile and "just" found these two. Any other redundancies?
```bash
        pdo \
        pdo_mysql \
        xml \
        gd \
        zip \
        opcache \
        posix \
        ctype \
        json \
        iconv \
        pcntl \
```