### PR TITLE
Replace HOSTNAME environment variable with SMTP_DOMAIN

### DIFF
--- a/.config/zz-docker.config.php
+++ b/.config/zz-docker.config.php
@@ -59,8 +59,4 @@ if (!empty(getenv('FRIENDICA_DEBUGGING'))) {
 	}
 }
 
-if (!empty(getenv('HOSTNAME'))) {
-	$config['config']['hostname'] = getenv('HOSTNAME');
-}
-
 return $config;

--- a/.examples/README.md
+++ b/.examples/README.md
@@ -55,7 +55,6 @@ Therefore you have to use adjust the `labels:` inside the `docker-compose.yml` t
 To use this example complete the following steps:
 
 1. open `docker-compose.yml`
-   1. insert your friendica domain behind `hostname:`
    2. insert your friendica domain at `traefik.friendica.rule=Host:friendica.local`
 2. choose a password for the database user in `db.env` behind `MYSQL_PASSWORD=`
 3. open `proxy/traefik.toml`

--- a/.examples/docker-compose/insecure/mariadb-cron-redis/apache/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/apache/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - db.env
     depends_on:
       - db
-    hostname: friendica.local
     ports:
       - "80:80"
 
@@ -45,7 +44,6 @@ services:
       - db
     env_file:
       - db.env
-    hostname: friendica.local
 
 volumes:
   db:

--- a/.examples/docker-compose/insecure/mariadb-cron-redis/fpm-alpine/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/fpm-alpine/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - db.env
     depends_on:
       - db
-    hostname: friendica.local
 
   cron:
     build: ./app
@@ -42,7 +41,6 @@ services:
     depends_on:
       - db
       - app
-    hostname: friendica.local
 
   web:
     image: nginx

--- a/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/docker-compose.yml
+++ b/.examples/docker-compose/insecure/mariadb-cron-redis/fpm/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - db.env
     depends_on:
       - db
-    hostname: friendica.local
 
   cron:
     build: ./app
@@ -42,7 +41,6 @@ services:
     depends_on:
       - db
       - app
-    hostname: friendica.local
 
   web:
     image: nginx

--- a/.examples/docker-compose/with-traefik-proxy/mariadb-cron-smtp/apache/docker-compose.yml
+++ b/.examples/docker-compose/with-traefik-proxy/mariadb-cron-smtp/apache/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - db.env
     depends_on:
       - db
-    hostname: friendica.local
     labels:
       - "traefik.backend=friendica"
       - "traefik.frontend.entryPoints=https"
@@ -53,7 +52,6 @@ services:
       - db.env
     depends_on:
       - db
-    hostname: friendica.local
 
   proxy:
     build: ./proxy

--- a/.examples/docker-compose/with-traefik-proxy/mariadb-cron-smtp/fpm-alpine/docker-compose.yml
+++ b/.examples/docker-compose/with-traefik-proxy/mariadb-cron-smtp/fpm-alpine/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - db.env
     depends_on:
       - db
-    hostname: friendica.local
 
   cron:
     build: ./app
@@ -40,7 +39,6 @@ services:
     depends_on:
       - db
       - app
-    hostname: friendica.local
 
   web:
     image: nginx

--- a/.examples/docker-compose/with-traefik-proxy/mariadb-cron-smtp/fpm/docker-compose.yml
+++ b/.examples/docker-compose/with-traefik-proxy/mariadb-cron-smtp/fpm/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - db.env
     depends_on:
       - db
-    hostname: friendica.local
 
   cron:
     build: ./app
@@ -40,7 +39,6 @@ services:
     depends_on:
       - db
       - app
-    hostname: friendica.local
 
   web:
     image: nginx

--- a/2019.12/apache/config/zz-docker.config.php
+++ b/2019.12/apache/config/zz-docker.config.php
@@ -59,8 +59,4 @@ if (!empty(getenv('FRIENDICA_DEBUGGING'))) {
 	}
 }
 
-if (!empty(getenv('HOSTNAME'))) {
-	$config['config']['hostname'] = getenv('HOSTNAME');
-}
-
 return $config;

--- a/2019.12/apache/entrypoint.sh
+++ b/2019.12/apache/entrypoint.sh
@@ -17,7 +17,7 @@ version_greater() {
 }
 
 setup_ssmtp() {
-	if [ -n "${HOSTNAME+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
+	if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
 		SITENAME="${FRIENDICA_SITENAME:-Friendica Social Network}"
 		echo "Setup SSMTP for '$SITENAME' with '$SMTP' ..."
 
@@ -29,14 +29,14 @@ setup_ssmtp() {
 
 		# add possible mail-senders
 		{
-		 echo "www-data:$smtp_from@$HOSTNAME:$SMTP"
-		 echo "root::$smtp_from@$HOSTNAME:$SMTP"
+		 echo "www-data:$smtp_from@$SMTP_DOMAIN:$SMTP"
+		 echo "root::$smtp_from@$SMTP_DOMAIN:$SMTP"
 		} > /etc/ssmtp/revaliases
 
 		# replace ssmtp.conf settings
 		{
-		 echo "root=:$smtp_from@$HOSTNAME"
-		 echo "hostname=$HOSTNAME"
+		 echo "root=:$smtp_from@$SMTP_DOMAIN"
+		 echo "hostname=$SMTP_DOMAIN"
 		 echo "mailhub=$SMTP"
 		 echo "FromLineOverride=YES"
 		 if [ -n "${SMTP_TLS+x}" ]; then echo "UseTLS=$SMTP_TLS"; fi

--- a/2019.12/fpm-alpine/config/zz-docker.config.php
+++ b/2019.12/fpm-alpine/config/zz-docker.config.php
@@ -59,8 +59,4 @@ if (!empty(getenv('FRIENDICA_DEBUGGING'))) {
 	}
 }
 
-if (!empty(getenv('HOSTNAME'))) {
-	$config['config']['hostname'] = getenv('HOSTNAME');
-}
-
 return $config;

--- a/2019.12/fpm-alpine/entrypoint.sh
+++ b/2019.12/fpm-alpine/entrypoint.sh
@@ -17,7 +17,7 @@ version_greater() {
 }
 
 setup_ssmtp() {
-	if [ -n "${HOSTNAME+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
+	if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
 		SITENAME="${FRIENDICA_SITENAME:-Friendica Social Network}"
 		echo "Setup SSMTP for '$SITENAME' with '$SMTP' ..."
 
@@ -29,14 +29,14 @@ setup_ssmtp() {
 
 		# add possible mail-senders
 		{
-		 echo "www-data:$smtp_from@$HOSTNAME:$SMTP"
-		 echo "root::$smtp_from@$HOSTNAME:$SMTP"
+		 echo "www-data:$smtp_from@$SMTP_DOMAIN:$SMTP"
+		 echo "root::$smtp_from@$SMTP_DOMAIN:$SMTP"
 		} > /etc/ssmtp/revaliases
 
 		# replace ssmtp.conf settings
 		{
-		 echo "root=:$smtp_from@$HOSTNAME"
-		 echo "hostname=$HOSTNAME"
+		 echo "root=:$smtp_from@$SMTP_DOMAIN"
+		 echo "hostname=$SMTP_DOMAIN"
 		 echo "mailhub=$SMTP"
 		 echo "FromLineOverride=YES"
 		 if [ -n "${SMTP_TLS+x}" ]; then echo "UseTLS=$SMTP_TLS"; fi

--- a/2019.12/fpm/config/zz-docker.config.php
+++ b/2019.12/fpm/config/zz-docker.config.php
@@ -59,8 +59,4 @@ if (!empty(getenv('FRIENDICA_DEBUGGING'))) {
 	}
 }
 
-if (!empty(getenv('HOSTNAME'))) {
-	$config['config']['hostname'] = getenv('HOSTNAME');
-}
-
 return $config;

--- a/2019.12/fpm/entrypoint.sh
+++ b/2019.12/fpm/entrypoint.sh
@@ -17,7 +17,7 @@ version_greater() {
 }
 
 setup_ssmtp() {
-	if [ -n "${HOSTNAME+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
+	if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
 		SITENAME="${FRIENDICA_SITENAME:-Friendica Social Network}"
 		echo "Setup SSMTP for '$SITENAME' with '$SMTP' ..."
 
@@ -29,14 +29,14 @@ setup_ssmtp() {
 
 		# add possible mail-senders
 		{
-		 echo "www-data:$smtp_from@$HOSTNAME:$SMTP"
-		 echo "root::$smtp_from@$HOSTNAME:$SMTP"
+		 echo "www-data:$smtp_from@$SMTP_DOMAIN:$SMTP"
+		 echo "root::$smtp_from@$SMTP_DOMAIN:$SMTP"
 		} > /etc/ssmtp/revaliases
 
 		# replace ssmtp.conf settings
 		{
-		 echo "root=:$smtp_from@$HOSTNAME"
-		 echo "hostname=$HOSTNAME"
+		 echo "root=:$smtp_from@$SMTP_DOMAIN"
+		 echo "hostname=$SMTP_DOMAIN"
 		 echo "mailhub=$SMTP"
 		 echo "FromLineOverride=YES"
 		 if [ -n "${SMTP_TLS+x}" ]; then echo "UseTLS=$SMTP_TLS"; fi

--- a/2020.03-dev/apache/config/zz-docker.config.php
+++ b/2020.03-dev/apache/config/zz-docker.config.php
@@ -59,8 +59,4 @@ if (!empty(getenv('FRIENDICA_DEBUGGING'))) {
 	}
 }
 
-if (!empty(getenv('HOSTNAME'))) {
-	$config['config']['hostname'] = getenv('HOSTNAME');
-}
-
 return $config;

--- a/2020.03-dev/apache/entrypoint.sh
+++ b/2020.03-dev/apache/entrypoint.sh
@@ -17,7 +17,7 @@ version_greater() {
 }
 
 setup_ssmtp() {
-	if [ -n "${HOSTNAME+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
+	if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
 		SITENAME="${FRIENDICA_SITENAME:-Friendica Social Network}"
 		echo "Setup SSMTP for '$SITENAME' with '$SMTP' ..."
 
@@ -29,14 +29,14 @@ setup_ssmtp() {
 
 		# add possible mail-senders
 		{
-		 echo "www-data:$smtp_from@$HOSTNAME:$SMTP"
-		 echo "root::$smtp_from@$HOSTNAME:$SMTP"
+		 echo "www-data:$smtp_from@$SMTP_DOMAIN:$SMTP"
+		 echo "root::$smtp_from@$SMTP_DOMAIN:$SMTP"
 		} > /etc/ssmtp/revaliases
 
 		# replace ssmtp.conf settings
 		{
-		 echo "root=:$smtp_from@$HOSTNAME"
-		 echo "hostname=$HOSTNAME"
+		 echo "root=:$smtp_from@$SMTP_DOMAIN"
+		 echo "hostname=$SMTP_DOMAIN"
 		 echo "mailhub=$SMTP"
 		 echo "FromLineOverride=YES"
 		 if [ -n "${SMTP_TLS+x}" ]; then echo "UseTLS=$SMTP_TLS"; fi

--- a/2020.03-dev/fpm-alpine/config/zz-docker.config.php
+++ b/2020.03-dev/fpm-alpine/config/zz-docker.config.php
@@ -59,8 +59,4 @@ if (!empty(getenv('FRIENDICA_DEBUGGING'))) {
 	}
 }
 
-if (!empty(getenv('HOSTNAME'))) {
-	$config['config']['hostname'] = getenv('HOSTNAME');
-}
-
 return $config;

--- a/2020.03-dev/fpm-alpine/entrypoint.sh
+++ b/2020.03-dev/fpm-alpine/entrypoint.sh
@@ -17,7 +17,7 @@ version_greater() {
 }
 
 setup_ssmtp() {
-	if [ -n "${HOSTNAME+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
+	if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
 		SITENAME="${FRIENDICA_SITENAME:-Friendica Social Network}"
 		echo "Setup SSMTP for '$SITENAME' with '$SMTP' ..."
 
@@ -29,14 +29,14 @@ setup_ssmtp() {
 
 		# add possible mail-senders
 		{
-		 echo "www-data:$smtp_from@$HOSTNAME:$SMTP"
-		 echo "root::$smtp_from@$HOSTNAME:$SMTP"
+		 echo "www-data:$smtp_from@$SMTP_DOMAIN:$SMTP"
+		 echo "root::$smtp_from@$SMTP_DOMAIN:$SMTP"
 		} > /etc/ssmtp/revaliases
 
 		# replace ssmtp.conf settings
 		{
-		 echo "root=:$smtp_from@$HOSTNAME"
-		 echo "hostname=$HOSTNAME"
+		 echo "root=:$smtp_from@$SMTP_DOMAIN"
+		 echo "hostname=$SMTP_DOMAIN"
 		 echo "mailhub=$SMTP"
 		 echo "FromLineOverride=YES"
 		 if [ -n "${SMTP_TLS+x}" ]; then echo "UseTLS=$SMTP_TLS"; fi

--- a/2020.03-dev/fpm/config/zz-docker.config.php
+++ b/2020.03-dev/fpm/config/zz-docker.config.php
@@ -59,8 +59,4 @@ if (!empty(getenv('FRIENDICA_DEBUGGING'))) {
 	}
 }
 
-if (!empty(getenv('HOSTNAME'))) {
-	$config['config']['hostname'] = getenv('HOSTNAME');
-}
-
 return $config;

--- a/2020.03-dev/fpm/entrypoint.sh
+++ b/2020.03-dev/fpm/entrypoint.sh
@@ -17,7 +17,7 @@ version_greater() {
 }
 
 setup_ssmtp() {
-	if [ -n "${HOSTNAME+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
+	if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
 		SITENAME="${FRIENDICA_SITENAME:-Friendica Social Network}"
 		echo "Setup SSMTP for '$SITENAME' with '$SMTP' ..."
 
@@ -29,14 +29,14 @@ setup_ssmtp() {
 
 		# add possible mail-senders
 		{
-		 echo "www-data:$smtp_from@$HOSTNAME:$SMTP"
-		 echo "root::$smtp_from@$HOSTNAME:$SMTP"
+		 echo "www-data:$smtp_from@$SMTP_DOMAIN:$SMTP"
+		 echo "root::$smtp_from@$SMTP_DOMAIN:$SMTP"
 		} > /etc/ssmtp/revaliases
 
 		# replace ssmtp.conf settings
 		{
-		 echo "root=:$smtp_from@$HOSTNAME"
-		 echo "hostname=$HOSTNAME"
+		 echo "root=:$smtp_from@$SMTP_DOMAIN"
+		 echo "hostname=$SMTP_DOMAIN"
 		 echo "mailhub=$SMTP"
 		 echo "FromLineOverride=YES"
 		 if [ -n "${SMTP_TLS+x}" ]; then echo "UseTLS=$SMTP_TLS"; fi

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ A valid SMTP-MTA would be, for example, `mx.example.org`.
 
 The following environment variables are possible for the SMTP examples.
 
--	`SITENAME` The name of the Friendica node. (**required**)
 -	`SMTP` Address of the SMTP Mail-Gateway. (**required**)
+-	`SMTP_DOMAIN` The sender domain. (**required** - e.g. `friendica.local`)
 -	`SMTP_FROM` Sender user-part of the address. (Default: `no-reply` - e.g. no-reply@friendica.local)
 -	`SMTP_TLS` Use TLS for connecting the SMTP Mail-Gateway. (Default: empty)
 -	`SMTP_STARTTLS` Use STARTTLS for connecting the SMTP Mail-Gateway. (Default: empty)
@@ -214,7 +214,6 @@ services:
       - MYSQL_PASSWORD=
       - MYSQL_DATABASE=friendica
       - FRIENDICA_ADMIN_MAIL=root@friendica.local      
-    hostname: friendica.local
     depends_on:
       - db
 
@@ -269,7 +268,6 @@ services:
       - MYSQL_PASSWORD=
       - MYSQL_DATABASE=friendica
       - FRIENDICA_ADMIN_MAIL=root@friendica.local
-    hostname: friendica.local
     networks:
       - proxy-tier
       - default 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,7 +17,7 @@ version_greater() {
 }
 
 setup_ssmtp() {
-	if [ -n "${HOSTNAME+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
+	if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost" ]; then
 		SITENAME="${FRIENDICA_SITENAME:-Friendica Social Network}"
 		echo "Setup SSMTP for '$SITENAME' with '$SMTP' ..."
 
@@ -29,14 +29,14 @@ setup_ssmtp() {
 
 		# add possible mail-senders
 		{
-		 echo "www-data:$smtp_from@$HOSTNAME:$SMTP"
-		 echo "root::$smtp_from@$HOSTNAME:$SMTP"
+		 echo "www-data:$smtp_from@$SMTP_DOMAIN:$SMTP"
+		 echo "root::$smtp_from@$SMTP_DOMAIN:$SMTP"
 		} > /etc/ssmtp/revaliases
 
 		# replace ssmtp.conf settings
 		{
-		 echo "root=:$smtp_from@$HOSTNAME"
-		 echo "hostname=$HOSTNAME"
+		 echo "root=:$smtp_from@$SMTP_DOMAIN"
+		 echo "hostname=$SMTP_DOMAIN"
 		 echo "mailhub=$SMTP"
 		 echo "FromLineOverride=YES"
 		 if [ -n "${SMTP_TLS+x}" ]; then echo "UseTLS=$SMTP_TLS"; fi


### PR DESCRIPTION
Fixes https://github.com/friendica/docker/issues/79
Replaces the usage of `HOSTNAME` with `SMTP_DOMAIN`.

Now it isn't required anymore to have set the `hostname` parameter of docker to make the SMTP setting work. 