### PR TITLE
Force docker upgrade at startup

### DIFF
--- a/2020.09/apache/entrypoint.sh
+++ b/2020.09/apache/entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update'
+      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
       echo "Upgrading finished"
     fi
   fi

--- a/2020.09/fpm-alpine/entrypoint.sh
+++ b/2020.09/fpm-alpine/entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update'
+      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
       echo "Upgrading finished"
     fi
   fi

--- a/2020.09/fpm/entrypoint.sh
+++ b/2020.09/fpm/entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update'
+      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
       echo "Upgrading finished"
     fi
   fi

--- a/2020.12-dev/apache/entrypoint.sh
+++ b/2020.12-dev/apache/entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update'
+      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
       echo "Upgrading finished"
     fi
   fi

--- a/2020.12-dev/fpm-alpine/entrypoint.sh
+++ b/2020.12-dev/fpm-alpine/entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update'
+      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
       echo "Upgrading finished"
     fi
   fi

--- a/2020.12-dev/fpm/entrypoint.sh
+++ b/2020.12-dev/fpm/entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update'
+      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
       echo "Upgrading finished"
     fi
   fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update'
+      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
       echo "Upgrading finished"
     fi
   fi


### PR DESCRIPTION
There're situations where the upgrade is skipped, but the worker didn't upgrade the node fast enough, so the service was responding with a lot of errors meanwhile.

This change should now force the upgrade of the db before starting the service again.