### PR TITLE
set /etc/msmtprc 'auth' parameter from SMTP_AUTH env

### DIFF
--- a/2020.09/apache/setup_msmtp.sh
+++ b/2020.09/apache/setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"

--- a/2020.09/fpm-alpine/setup_msmtp.sh
+++ b/2020.09/fpm-alpine/setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"

--- a/2020.09/fpm/setup_msmtp.sh
+++ b/2020.09/fpm/setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"

--- a/2021.01/apache/setup_msmtp.sh
+++ b/2021.01/apache/setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"

--- a/2021.01/fpm-alpine/setup_msmtp.sh
+++ b/2021.01/fpm-alpine/setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"

--- a/2021.01/fpm/setup_msmtp.sh
+++ b/2021.01/fpm/setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"

--- a/2021.03-dev/apache/setup_msmtp.sh
+++ b/2021.03-dev/apache/setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"

--- a/2021.03-dev/fpm-alpine/setup_msmtp.sh
+++ b/2021.03-dev/fpm-alpine/setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"

--- a/2021.03-dev/fpm/setup_msmtp.sh
+++ b/2021.03-dev/fpm/setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"

--- a/2021.03-rc/apache/setup_msmtp.sh
+++ b/2021.03-rc/apache/setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"

--- a/2021.03-rc/fpm-alpine/setup_msmtp.sh
+++ b/2021.03-rc/fpm-alpine/setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"

--- a/2021.03-rc/fpm/setup_msmtp.sh
+++ b/2021.03-rc/fpm/setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The following environment variables are possible for the SMTP examples.
 -	`SMTP_FROM` Sender user-part of the address. (Default: `no-reply` - e.g. no-reply@friendica.local)
 -	`SMTP_TLS` Use TLS for connecting the SMTP Mail-Gateway. (Default: empty)
 -	`SMTP_STARTTLS` Use STARTTLS for connecting the SMTP Mail-Gateway. (Default: empty)
+-       `SMTP_AUTH` Auth mode for the SMTP Mail-Gateway. (Default: `On`)
 -	`SMTP_AUTH_USER` Username for the SMTP Mail-Gateway. (Default: empty)
 -	`SMTP_AUTH_PASS` Password for the SMTP Mail-Gateway. (Default: empty)
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The following environment variables are possible for the SMTP examples.
 -	`SMTP_FROM` Sender user-part of the address. (Default: `no-reply` - e.g. no-reply@friendica.local)
 -	`SMTP_TLS` Use TLS for connecting the SMTP Mail-Gateway. (Default: empty)
 -	`SMTP_STARTTLS` Use STARTTLS for connecting the SMTP Mail-Gateway. (Default: empty)
-- `SMTP_AUTH` Auth mode for the SMTP Mail-Gateway. (Default: `On`)
+-	`SMTP_AUTH` Auth mode for the SMTP Mail-Gateway. (Default: `On`)
 -	`SMTP_AUTH_USER` Username for the SMTP Mail-Gateway. (Default: empty)
 -	`SMTP_AUTH_PASS` Password for the SMTP Mail-Gateway. (Default: empty)
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The following environment variables are possible for the SMTP examples.
 -	`SMTP_FROM` Sender user-part of the address. (Default: `no-reply` - e.g. no-reply@friendica.local)
 -	`SMTP_TLS` Use TLS for connecting the SMTP Mail-Gateway. (Default: empty)
 -	`SMTP_STARTTLS` Use STARTTLS for connecting the SMTP Mail-Gateway. (Default: empty)
--       `SMTP_AUTH` Auth mode for the SMTP Mail-Gateway. (Default: `On`)
+- `SMTP_AUTH` Auth mode for the SMTP Mail-Gateway. (Default: `On`)
 -	`SMTP_AUTH_USER` Username for the SMTP Mail-Gateway. (Default: empty)
 -	`SMTP_AUTH_PASS` Password for the SMTP Mail-Gateway. (Default: empty)
 

--- a/docker-setup_msmtp.sh
+++ b/docker-setup_msmtp.sh
@@ -6,6 +6,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
   echo "Setup MSMTP for '$SITENAME' with '$SMTP' ..."
 
   smtp_from="${SMTP_FROM:=no-reply}"
+  smtp_auth="${SMTP_AUTH:=on}"
 
   # Setup MSMTP
   usermod --comment "$(echo "$SITENAME" | tr -dc '[:print:]')" root
@@ -26,7 +27,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     echo "tls_certcheck off" # No certcheck because of internal docker mail-hostnames
     if [ -n "${SMTP_TLS+x}" ]; then echo "tls on"; fi
     if [ -n "${SMTP_STARTTLS+x}" ]; then echo "tls_starttls on"; fi
-    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth on"; fi
+    if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
     echo "logfile /var/log/msmtp.log"


### PR DESCRIPTION
In some cases smtp config parameter  'auth login' instead 'auth on' is needed to avoid msmtp errors.  