### PR TITLE
Revert "Force docker upgrade at startup"

### DIFF
--- a/2020.09/apache/entrypoint.sh
+++ b/2020.09/apache/entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
+      run_as 'php /var/www/html/bin/console.php dbstructure update'
       echo "Upgrading finished"
     fi
   fi

--- a/2020.09/fpm-alpine/entrypoint.sh
+++ b/2020.09/fpm-alpine/entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
+      run_as 'php /var/www/html/bin/console.php dbstructure update'
       echo "Upgrading finished"
     fi
   fi

--- a/2020.09/fpm/entrypoint.sh
+++ b/2020.09/fpm/entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
+      run_as 'php /var/www/html/bin/console.php dbstructure update'
       echo "Upgrading finished"
     fi
   fi

--- a/2021.01/apache/entrypoint.sh
+++ b/2021.01/apache/entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
+      run_as 'php /var/www/html/bin/console.php dbstructure update'
       echo "Upgrading finished"
     fi
   fi

--- a/2021.01/fpm-alpine/entrypoint.sh
+++ b/2021.01/fpm-alpine/entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
+      run_as 'php /var/www/html/bin/console.php dbstructure update'
       echo "Upgrading finished"
     fi
   fi

--- a/2021.01/fpm/entrypoint.sh
+++ b/2021.01/fpm/entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
+      run_as 'php /var/www/html/bin/console.php dbstructure update'
       echo "Upgrading finished"
     fi
   fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -136,7 +136,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     # upgrade
     else
       echo "Upgrading Friendica ..."
-      run_as 'php /var/www/html/bin/console.php dbstructure update -f'
+      run_as 'php /var/www/html/bin/console.php dbstructure update'
       echo "Upgrading finished"
     fi
   fi


### PR DESCRIPTION
This reverts the force (`-f` flag) of the database upgrade on startup,
as per the discussion in https://github.com/friendica/friendica/issues/10375#issuecomment-855604924 and https://github.com/friendica/docker/pull/137#issuecomment-857431269