### PR TITLE
Execute cron as www-data

### DIFF
--- a/2021.04/apache/Dockerfile
+++ b/2021.04/apache/Dockerfile
@@ -11,21 +11,13 @@ RUN set -ex; \
         git \
 # For mail() support
         msmtp \
-# For tini installation
-        gnupg dirmngr \
+        tini \
+# For setuid/setgid support
+        gosu \
     ; \
+# Verify that the binary works
+    gosu nobody true; \
     rm -rf /var/lib/apt/lists/*;
-
-# Add tini for reaping processes
-ENV TINI_VERSION v0.19.0
-RUN export BUILD_ARCH=$(dpkg-architecture --query DEB_BUILD_ARCH) \
- && mkdir ~/.gnupg \
- && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && curl -L -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH} \
- && curl -L -o /tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH}.asc \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
- && gpg --batch --verify /tini.asc /sbin/tini \
- && chmod +x /sbin/tini
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/2021.04/apache/cron.sh
+++ b/2021.04/apache/cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi

--- a/2021.04/fpm-alpine/Dockerfile
+++ b/2021.04/fpm-alpine/Dockerfile
@@ -11,6 +11,34 @@ RUN set -ex; \
         shadow \
         tini;
 
+ENV GOSU_VERSION 1.14
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	command -v gpgconf && gpgconf --kill all || :; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+# clean up fetch dependencies
+	apk del --no-network .gosu-deps; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu --version; \
+	gosu nobody true
+
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/
 RUN set -ex; \

--- a/2021.04/fpm-alpine/cron.sh
+++ b/2021.04/fpm-alpine/cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi

--- a/2021.04/fpm/Dockerfile
+++ b/2021.04/fpm/Dockerfile
@@ -11,21 +11,13 @@ RUN set -ex; \
         git \
 # For mail() support
         msmtp \
-# For tini installation
-        gnupg dirmngr \
+        tini \
+# For setuid/setgid support
+        gosu \
     ; \
+# Verify that the binary works
+    gosu nobody true; \
     rm -rf /var/lib/apt/lists/*;
-
-# Add tini for reaping processes
-ENV TINI_VERSION v0.19.0
-RUN export BUILD_ARCH=$(dpkg-architecture --query DEB_BUILD_ARCH) \
- && mkdir ~/.gnupg \
- && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && curl -L -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH} \
- && curl -L -o /tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH}.asc \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
- && gpg --batch --verify /tini.asc /sbin/tini \
- && chmod +x /sbin/tini
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/2021.04/fpm/cron.sh
+++ b/2021.04/fpm/cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi

--- a/2021.07/apache/Dockerfile
+++ b/2021.07/apache/Dockerfile
@@ -11,21 +11,13 @@ RUN set -ex; \
         git \
 # For mail() support
         msmtp \
-# For tini installation
-        gnupg dirmngr \
+        tini \
+# For setuid/setgid support
+        gosu \
     ; \
+# Verify that the binary works
+    gosu nobody true; \
     rm -rf /var/lib/apt/lists/*;
-
-# Add tini for reaping processes
-ENV TINI_VERSION v0.19.0
-RUN export BUILD_ARCH=$(dpkg-architecture --query DEB_BUILD_ARCH) \
- && mkdir ~/.gnupg \
- && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && curl -L -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH} \
- && curl -L -o /tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH}.asc \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
- && gpg --batch --verify /tini.asc /sbin/tini \
- && chmod +x /sbin/tini
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/2021.07/apache/cron.sh
+++ b/2021.07/apache/cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi

--- a/2021.07/fpm-alpine/Dockerfile
+++ b/2021.07/fpm-alpine/Dockerfile
@@ -11,6 +11,34 @@ RUN set -ex; \
         shadow \
         tini;
 
+ENV GOSU_VERSION 1.14
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	command -v gpgconf && gpgconf --kill all || :; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+# clean up fetch dependencies
+	apk del --no-network .gosu-deps; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu --version; \
+	gosu nobody true
+
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/
 RUN set -ex; \

--- a/2021.07/fpm-alpine/cron.sh
+++ b/2021.07/fpm-alpine/cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi

--- a/2021.07/fpm/Dockerfile
+++ b/2021.07/fpm/Dockerfile
@@ -11,21 +11,13 @@ RUN set -ex; \
         git \
 # For mail() support
         msmtp \
-# For tini installation
-        gnupg dirmngr \
+        tini \
+# For setuid/setgid support
+        gosu \
     ; \
+# Verify that the binary works
+    gosu nobody true; \
     rm -rf /var/lib/apt/lists/*;
-
-# Add tini for reaping processes
-ENV TINI_VERSION v0.19.0
-RUN export BUILD_ARCH=$(dpkg-architecture --query DEB_BUILD_ARCH) \
- && mkdir ~/.gnupg \
- && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && curl -L -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH} \
- && curl -L -o /tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH}.asc \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
- && gpg --batch --verify /tini.asc /sbin/tini \
- && chmod +x /sbin/tini
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/2021.07/fpm/cron.sh
+++ b/2021.07/fpm/cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi

--- a/2021.09-dev/apache/Dockerfile
+++ b/2021.09-dev/apache/Dockerfile
@@ -11,21 +11,13 @@ RUN set -ex; \
         git \
 # For mail() support
         msmtp \
-# For tini installation
-        gnupg dirmngr \
+        tini \
+# For setuid/setgid support
+        gosu \
     ; \
+# Verify that the binary works
+    gosu nobody true; \
     rm -rf /var/lib/apt/lists/*;
-
-# Add tini for reaping processes
-ENV TINI_VERSION v0.19.0
-RUN export BUILD_ARCH=$(dpkg-architecture --query DEB_BUILD_ARCH) \
- && mkdir ~/.gnupg \
- && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && curl -L -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH} \
- && curl -L -o /tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH}.asc \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
- && gpg --batch --verify /tini.asc /sbin/tini \
- && chmod +x /sbin/tini
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/2021.09-dev/apache/cron.sh
+++ b/2021.09-dev/apache/cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi

--- a/2021.09-dev/fpm-alpine/Dockerfile
+++ b/2021.09-dev/fpm-alpine/Dockerfile
@@ -11,6 +11,34 @@ RUN set -ex; \
         shadow \
         tini;
 
+ENV GOSU_VERSION 1.14
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	command -v gpgconf && gpgconf --kill all || :; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+# clean up fetch dependencies
+	apk del --no-network .gosu-deps; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu --version; \
+	gosu nobody true
+
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/
 RUN set -ex; \

--- a/2021.09-dev/fpm-alpine/cron.sh
+++ b/2021.09-dev/fpm-alpine/cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi

--- a/2021.09-dev/fpm/Dockerfile
+++ b/2021.09-dev/fpm/Dockerfile
@@ -11,21 +11,13 @@ RUN set -ex; \
         git \
 # For mail() support
         msmtp \
-# For tini installation
-        gnupg dirmngr \
+        tini \
+# For setuid/setgid support
+        gosu \
     ; \
+# Verify that the binary works
+    gosu nobody true; \
     rm -rf /var/lib/apt/lists/*;
-
-# Add tini for reaping processes
-ENV TINI_VERSION v0.19.0
-RUN export BUILD_ARCH=$(dpkg-architecture --query DEB_BUILD_ARCH) \
- && mkdir ~/.gnupg \
- && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && curl -L -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH} \
- && curl -L -o /tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH}.asc \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
- && gpg --batch --verify /tini.asc /sbin/tini \
- && chmod +x /sbin/tini
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/2021.09-dev/fpm/cron.sh
+++ b/2021.09-dev/fpm/cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi

--- a/2021.09-rc/apache/Dockerfile
+++ b/2021.09-rc/apache/Dockerfile
@@ -11,21 +11,13 @@ RUN set -ex; \
         git \
 # For mail() support
         msmtp \
-# For tini installation
-        gnupg dirmngr \
+        tini \
+# For setuid/setgid support
+        gosu \
     ; \
+# Verify that the binary works
+    gosu nobody true; \
     rm -rf /var/lib/apt/lists/*;
-
-# Add tini for reaping processes
-ENV TINI_VERSION v0.19.0
-RUN export BUILD_ARCH=$(dpkg-architecture --query DEB_BUILD_ARCH) \
- && mkdir ~/.gnupg \
- && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && curl -L -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH} \
- && curl -L -o /tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH}.asc \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
- && gpg --batch --verify /tini.asc /sbin/tini \
- && chmod +x /sbin/tini
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/2021.09-rc/apache/cron.sh
+++ b/2021.09-rc/apache/cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi

--- a/2021.09-rc/fpm-alpine/Dockerfile
+++ b/2021.09-rc/fpm-alpine/Dockerfile
@@ -11,6 +11,34 @@ RUN set -ex; \
         shadow \
         tini;
 
+ENV GOSU_VERSION 1.14
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	command -v gpgconf && gpgconf --kill all || :; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+# clean up fetch dependencies
+	apk del --no-network .gosu-deps; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu --version; \
+	gosu nobody true
+
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/
 RUN set -ex; \

--- a/2021.09-rc/fpm-alpine/cron.sh
+++ b/2021.09-rc/fpm-alpine/cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi

--- a/2021.09-rc/fpm/Dockerfile
+++ b/2021.09-rc/fpm/Dockerfile
@@ -11,21 +11,13 @@ RUN set -ex; \
         git \
 # For mail() support
         msmtp \
-# For tini installation
-        gnupg dirmngr \
+        tini \
+# For setuid/setgid support
+        gosu \
     ; \
+# Verify that the binary works
+    gosu nobody true; \
     rm -rf /var/lib/apt/lists/*;
-
-# Add tini for reaping processes
-ENV TINI_VERSION v0.19.0
-RUN export BUILD_ARCH=$(dpkg-architecture --query DEB_BUILD_ARCH) \
- && mkdir ~/.gnupg \
- && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && curl -L -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH} \
- && curl -L -o /tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH}.asc \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
- && gpg --batch --verify /tini.asc /sbin/tini \
- && chmod +x /sbin/tini
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/2021.09-rc/fpm/cron.sh
+++ b/2021.09-rc/fpm/cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -10,6 +10,34 @@ RUN set -ex; \
         shadow \
         tini;
 
+ENV GOSU_VERSION 1.14
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	command -v gpgconf && gpgconf --kill all || :; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+# clean up fetch dependencies
+	apk del --no-network .gosu-deps; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu --version; \
+	gosu nobody true
+
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/
 RUN set -ex; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -10,21 +10,13 @@ RUN set -ex; \
         git \
 # For mail() support
         msmtp \
-# For tini installation
-        gnupg dirmngr \
+        tini \
+# For setuid/setgid support
+        gosu \
     ; \
+# Verify that the binary works
+    gosu nobody true; \
     rm -rf /var/lib/apt/lists/*;
-
-# Add tini for reaping processes
-ENV TINI_VERSION v%%TINI_VERSION%%
-RUN export BUILD_ARCH=$(dpkg-architecture --query DEB_BUILD_ARCH) \
- && mkdir ~/.gnupg \
- && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && curl -L -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH} \
- && curl -L -o /tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${BUILD_ARCH}.asc \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
- && gpg --batch --verify /tini.asc /sbin/tini \
- && chmod +x /sbin/tini
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/docker-cron.sh
+++ b/docker-cron.sh
@@ -8,7 +8,7 @@ done
 echo "Waiting for MySQL $MYSQL_HOST initialization..."
 if php /var/www/html/bin/wait-for-connection "$MYSQL_HOST" "${MYSQL_PORT:-3306}" 300; then
   sh /setup_msmtp.sh
-  exec /sbin/tini -- php /var/www/html/bin/daemon.php -f start
+  exec gosu www-data:www-data tini -- php /var/www/html/bin/daemon.php -f start
 else
   echo "[ERROR] Waited 300 seconds, no response" >&2
 fi


### PR DESCRIPTION
Closes #71 

- We now execute the `daemon.php` as www-data
- Simplify the download of `tini` for debian