### PR TITLE
Directly include sha256 checksum for stable images

### DIFF
--- a/2021.04/apache/Dockerfile
+++ b/2021.04/apache/Dockerfile
@@ -126,29 +126,24 @@ RUN set -ex;\
 
 ENV FRIENDICA_VERSION "2021.04"
 ENV FRIENDICA_ADDONS "2021.04"
+ENV FRIENDICA_DOWNLOAD_SHA256 "440d3a39cd701c3a4179f89fcb1a7197c3bf03f02c087c4a6e1bbe88932a1ce4"
+ENV FRIENDICA_DOWNLOAD_ADDONS_SHA256 "6c798634ce75d25bb71c80a00fcd3b6dd48be3ca2e233ca0f9ed80981cba83af"
 
 RUN set -ex; \
     curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz \
         "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"; \
-    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 \
-        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"; \
-    sha256sum -c friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256; \
+    echo "${FRIENDICA_DOWNLOAD_SHA256} *friendica-full-${FRIENDICA_VERSION}.tar.gz" | sha256sum -c; \
     tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/; \
     rm friendica-full-${FRIENDICA_VERSION}.tar.gz; \
-    rm friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256; \
     mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
             "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
-    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 \
-        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256"; \
-    sha256sum -c friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256; \
+    echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" | sha256sum -c; \
     mkdir -p /usr/src/friendica/proxy; \
     mkdir -p /usr/src/friendica/addon; \
     tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1; \
-    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
-    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256;
-
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz;
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/friendica/config/
 

--- a/2021.04/fpm-alpine/Dockerfile
+++ b/2021.04/fpm-alpine/Dockerfile
@@ -128,29 +128,24 @@ VOLUME /var/www/html
 
 ENV FRIENDICA_VERSION "2021.04"
 ENV FRIENDICA_ADDONS "2021.04"
+ENV FRIENDICA_DOWNLOAD_SHA256 "440d3a39cd701c3a4179f89fcb1a7197c3bf03f02c087c4a6e1bbe88932a1ce4"
+ENV FRIENDICA_DOWNLOAD_ADDONS_SHA256 "6c798634ce75d25bb71c80a00fcd3b6dd48be3ca2e233ca0f9ed80981cba83af"
 
 RUN set -ex; \
     curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz \
         "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"; \
-    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 \
-        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"; \
-    sha256sum -c friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256; \
+    echo "${FRIENDICA_DOWNLOAD_SHA256} *friendica-full-${FRIENDICA_VERSION}.tar.gz" | sha256sum -c; \
     tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/; \
     rm friendica-full-${FRIENDICA_VERSION}.tar.gz; \
-    rm friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256; \
     mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
             "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
-    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 \
-        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256"; \
-    sha256sum -c friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256; \
+    echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" | sha256sum -c; \
     mkdir -p /usr/src/friendica/proxy; \
     mkdir -p /usr/src/friendica/addon; \
     tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1; \
-    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
-    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256;
-
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz;
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/friendica/config/
 

--- a/2021.04/fpm/Dockerfile
+++ b/2021.04/fpm/Dockerfile
@@ -117,29 +117,24 @@ VOLUME /var/www/html
 
 ENV FRIENDICA_VERSION "2021.04"
 ENV FRIENDICA_ADDONS "2021.04"
+ENV FRIENDICA_DOWNLOAD_SHA256 "440d3a39cd701c3a4179f89fcb1a7197c3bf03f02c087c4a6e1bbe88932a1ce4"
+ENV FRIENDICA_DOWNLOAD_ADDONS_SHA256 "6c798634ce75d25bb71c80a00fcd3b6dd48be3ca2e233ca0f9ed80981cba83af"
 
 RUN set -ex; \
     curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz \
         "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"; \
-    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 \
-        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"; \
-    sha256sum -c friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256; \
+    echo "${FRIENDICA_DOWNLOAD_SHA256} *friendica-full-${FRIENDICA_VERSION}.tar.gz" | sha256sum -c; \
     tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/; \
     rm friendica-full-${FRIENDICA_VERSION}.tar.gz; \
-    rm friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256; \
     mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
             "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
-    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 \
-        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256"; \
-    sha256sum -c friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256; \
+    echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" | sha256sum -c; \
     mkdir -p /usr/src/friendica/proxy; \
     mkdir -p /usr/src/friendica/addon; \
     tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1; \
-    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
-    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256;
-
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz;
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/friendica/config/
 

--- a/2021.07/apache/Dockerfile
+++ b/2021.07/apache/Dockerfile
@@ -126,29 +126,24 @@ RUN set -ex;\
 
 ENV FRIENDICA_VERSION "2021.07"
 ENV FRIENDICA_ADDONS "2021.07"
+ENV FRIENDICA_DOWNLOAD_SHA256 "d57ebb33ff733f0ad023ad63e8992d8f61cec06363b951d00f1452760eeeda12"
+ENV FRIENDICA_DOWNLOAD_ADDONS_SHA256 "9752046c5af1003338a668683b24476cfb3f8dfeaef466703492a0883581c790"
 
 RUN set -ex; \
     curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz \
         "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"; \
-    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 \
-        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"; \
-    sha256sum -c friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256; \
+    echo "${FRIENDICA_DOWNLOAD_SHA256} *friendica-full-${FRIENDICA_VERSION}.tar.gz" | sha256sum -c; \
     tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/; \
     rm friendica-full-${FRIENDICA_VERSION}.tar.gz; \
-    rm friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256; \
     mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
             "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
-    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 \
-        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256"; \
-    sha256sum -c friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256; \
+    echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" | sha256sum -c; \
     mkdir -p /usr/src/friendica/proxy; \
     mkdir -p /usr/src/friendica/addon; \
     tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1; \
-    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
-    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256;
-
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz;
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/friendica/config/
 

--- a/2021.07/fpm-alpine/Dockerfile
+++ b/2021.07/fpm-alpine/Dockerfile
@@ -128,29 +128,24 @@ VOLUME /var/www/html
 
 ENV FRIENDICA_VERSION "2021.07"
 ENV FRIENDICA_ADDONS "2021.07"
+ENV FRIENDICA_DOWNLOAD_SHA256 "d57ebb33ff733f0ad023ad63e8992d8f61cec06363b951d00f1452760eeeda12"
+ENV FRIENDICA_DOWNLOAD_ADDONS_SHA256 "9752046c5af1003338a668683b24476cfb3f8dfeaef466703492a0883581c790"
 
 RUN set -ex; \
     curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz \
         "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"; \
-    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 \
-        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"; \
-    sha256sum -c friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256; \
+    echo "${FRIENDICA_DOWNLOAD_SHA256} *friendica-full-${FRIENDICA_VERSION}.tar.gz" | sha256sum -c; \
     tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/; \
     rm friendica-full-${FRIENDICA_VERSION}.tar.gz; \
-    rm friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256; \
     mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
             "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
-    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 \
-        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256"; \
-    sha256sum -c friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256; \
+    echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" | sha256sum -c; \
     mkdir -p /usr/src/friendica/proxy; \
     mkdir -p /usr/src/friendica/addon; \
     tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1; \
-    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
-    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256;
-
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz;
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/friendica/config/
 

--- a/2021.07/fpm/Dockerfile
+++ b/2021.07/fpm/Dockerfile
@@ -117,29 +117,24 @@ VOLUME /var/www/html
 
 ENV FRIENDICA_VERSION "2021.07"
 ENV FRIENDICA_ADDONS "2021.07"
+ENV FRIENDICA_DOWNLOAD_SHA256 "d57ebb33ff733f0ad023ad63e8992d8f61cec06363b951d00f1452760eeeda12"
+ENV FRIENDICA_DOWNLOAD_ADDONS_SHA256 "9752046c5af1003338a668683b24476cfb3f8dfeaef466703492a0883581c790"
 
 RUN set -ex; \
     curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz \
         "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"; \
-    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 \
-        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"; \
-    sha256sum -c friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256; \
+    echo "${FRIENDICA_DOWNLOAD_SHA256} *friendica-full-${FRIENDICA_VERSION}.tar.gz" | sha256sum -c; \
     tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/; \
     rm friendica-full-${FRIENDICA_VERSION}.tar.gz; \
-    rm friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256; \
     mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
             "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
-    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 \
-        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256"; \
-    sha256sum -c friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256; \
+    echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" | sha256sum -c; \
     mkdir -p /usr/src/friendica/proxy; \
     mkdir -p /usr/src/friendica/addon; \
     tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1; \
-    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
-    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256;
-
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz;
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/friendica/config/
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -127,8 +127,8 @@ VOLUME /var/www/html
 
 ENV FRIENDICA_VERSION "%%VERSION%%"
 ENV FRIENDICA_ADDONS "%%VERSION%%"
+%%DOWNLOAD_SHA256%%
 %%INSTALL_EXTRAS%%
-
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/friendica/config/
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -116,8 +116,8 @@ VOLUME /var/www/html
 
 ENV FRIENDICA_VERSION "%%VERSION%%"
 ENV FRIENDICA_ADDONS "%%VERSION%%"
+%%DOWNLOAD_SHA256%%
 %%INSTALL_EXTRAS%%
-
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/friendica/config/
 


### PR DESCRIPTION
FollowUp #161 
Addresses feedback at https://github.com/docker-library/official-images/pull/10851#issuecomment-914682015

And @MrPetovan - You were right that downloading the SHA256 directly isn't a valid way :D