### PR TITLE
Add SHA256 check for dev/rc images

### DIFF
--- a/2021.09-dev/apache/entrypoint-dev.sh
+++ b/2021.09-dev/apache/entrypoint-dev.sh
@@ -3,38 +3,52 @@ set -eu
 
 # just check if we execute apache or php-fpm
 if (expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]) && [ "${FRIENDICA_DISABLE_UPGRADE:-false}" = "false" ]; then
-  echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
+  curl -fsSL -o "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"
+  curl -fsSL -o "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_ADDONS}.tar.gz.sum256"
 
-  # Removing the whole directory first
-  rm -fr /usr/src/friendica
-  export GNUPGHOME="$(mktemp -d)"
+  # Don't download already latest sources
+  if [ -f "/usr/src/friendica.tar.gz.sum256" ] && [ -f "/usr/src/friendica-addons.tar.gz.sum256" ] && \
+    cmp -s "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "/usr/src/friendica.tar.gz.sum256" && \
+    cmp -s "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "/usr/src/friendica-addons.tar.gz.sum256"; then
+     echo "Already latest sources - skipped download"
+  else
 
-  gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
+    echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
 
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
-  echo "Core sources (${FRIENDICA_VERSION}) verified"
+    # Removing the whole directory first
+    rm -fr /usr/src/friendica
+    export GNUPGHOME="$(mktemp -d)"
 
-  tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
-  rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
-  mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
-  echo "Core sources (${FRIENDICA_VERSION}) extracted"
+    gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
 
-  chmod 777 /usr/src/friendica/view/smarty3
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
+    echo "Core sources (${FRIENDICA_VERSION}) verified"
 
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
-  echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+    tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
+    rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
+    echo "Core sources (${FRIENDICA_VERSION}) extracted"
 
-  mkdir -p /usr/src/friendica/addon
-  tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
-  rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
-  echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+    chmod 777 /usr/src/friendica/view/smarty3
 
-  gpgconf --kill all
-  rm -rf "$GNUPGHOME"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
+    echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+
+    mkdir -p /usr/src/friendica/addon
+    tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
+    echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+
+    gpgconf --kill all
+    rm -rf "$GNUPGHOME"
+
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 /usr/src/friendica.tar.gz.sum256
+    mv -f /usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 /usr/src/friendica-addons.tar.gz.sum256
+  fi
 fi
 
 exec /entrypoint.sh "$@"

--- a/2021.09-dev/fpm-alpine/entrypoint-dev.sh
+++ b/2021.09-dev/fpm-alpine/entrypoint-dev.sh
@@ -3,38 +3,52 @@ set -eu
 
 # just check if we execute apache or php-fpm
 if (expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]) && [ "${FRIENDICA_DISABLE_UPGRADE:-false}" = "false" ]; then
-  echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
+  curl -fsSL -o "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"
+  curl -fsSL -o "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_ADDONS}.tar.gz.sum256"
 
-  # Removing the whole directory first
-  rm -fr /usr/src/friendica
-  export GNUPGHOME="$(mktemp -d)"
+  # Don't download already latest sources
+  if [ -f "/usr/src/friendica.tar.gz.sum256" ] && [ -f "/usr/src/friendica-addons.tar.gz.sum256" ] && \
+    cmp -s "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "/usr/src/friendica.tar.gz.sum256" && \
+    cmp -s "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "/usr/src/friendica-addons.tar.gz.sum256"; then
+     echo "Already latest sources - skipped download"
+  else
 
-  gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
+    echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
 
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
-  echo "Core sources (${FRIENDICA_VERSION}) verified"
+    # Removing the whole directory first
+    rm -fr /usr/src/friendica
+    export GNUPGHOME="$(mktemp -d)"
 
-  tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
-  rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
-  mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
-  echo "Core sources (${FRIENDICA_VERSION}) extracted"
+    gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
 
-  chmod 777 /usr/src/friendica/view/smarty3
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
+    echo "Core sources (${FRIENDICA_VERSION}) verified"
 
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
-  echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+    tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
+    rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
+    echo "Core sources (${FRIENDICA_VERSION}) extracted"
 
-  mkdir -p /usr/src/friendica/addon
-  tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
-  rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
-  echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+    chmod 777 /usr/src/friendica/view/smarty3
 
-  gpgconf --kill all
-  rm -rf "$GNUPGHOME"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
+    echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+
+    mkdir -p /usr/src/friendica/addon
+    tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
+    echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+
+    gpgconf --kill all
+    rm -rf "$GNUPGHOME"
+
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 /usr/src/friendica.tar.gz.sum256
+    mv -f /usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 /usr/src/friendica-addons.tar.gz.sum256
+  fi
 fi
 
 exec /entrypoint.sh "$@"

--- a/2021.09-dev/fpm/entrypoint-dev.sh
+++ b/2021.09-dev/fpm/entrypoint-dev.sh
@@ -3,38 +3,52 @@ set -eu
 
 # just check if we execute apache or php-fpm
 if (expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]) && [ "${FRIENDICA_DISABLE_UPGRADE:-false}" = "false" ]; then
-  echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
+  curl -fsSL -o "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"
+  curl -fsSL -o "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_ADDONS}.tar.gz.sum256"
 
-  # Removing the whole directory first
-  rm -fr /usr/src/friendica
-  export GNUPGHOME="$(mktemp -d)"
+  # Don't download already latest sources
+  if [ -f "/usr/src/friendica.tar.gz.sum256" ] && [ -f "/usr/src/friendica-addons.tar.gz.sum256" ] && \
+    cmp -s "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "/usr/src/friendica.tar.gz.sum256" && \
+    cmp -s "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "/usr/src/friendica-addons.tar.gz.sum256"; then
+     echo "Already latest sources - skipped download"
+  else
 
-  gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
+    echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
 
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
-  echo "Core sources (${FRIENDICA_VERSION}) verified"
+    # Removing the whole directory first
+    rm -fr /usr/src/friendica
+    export GNUPGHOME="$(mktemp -d)"
 
-  tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
-  rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
-  mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
-  echo "Core sources (${FRIENDICA_VERSION}) extracted"
+    gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
 
-  chmod 777 /usr/src/friendica/view/smarty3
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
+    echo "Core sources (${FRIENDICA_VERSION}) verified"
 
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
-  echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+    tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
+    rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
+    echo "Core sources (${FRIENDICA_VERSION}) extracted"
 
-  mkdir -p /usr/src/friendica/addon
-  tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
-  rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
-  echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+    chmod 777 /usr/src/friendica/view/smarty3
 
-  gpgconf --kill all
-  rm -rf "$GNUPGHOME"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
+    echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+
+    mkdir -p /usr/src/friendica/addon
+    tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
+    echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+
+    gpgconf --kill all
+    rm -rf "$GNUPGHOME"
+
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 /usr/src/friendica.tar.gz.sum256
+    mv -f /usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 /usr/src/friendica-addons.tar.gz.sum256
+  fi
 fi
 
 exec /entrypoint.sh "$@"

--- a/2021.09-rc/apache/entrypoint-dev.sh
+++ b/2021.09-rc/apache/entrypoint-dev.sh
@@ -3,38 +3,52 @@ set -eu
 
 # just check if we execute apache or php-fpm
 if (expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]) && [ "${FRIENDICA_DISABLE_UPGRADE:-false}" = "false" ]; then
-  echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
+  curl -fsSL -o "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"
+  curl -fsSL -o "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_ADDONS}.tar.gz.sum256"
 
-  # Removing the whole directory first
-  rm -fr /usr/src/friendica
-  export GNUPGHOME="$(mktemp -d)"
+  # Don't download already latest sources
+  if [ -f "/usr/src/friendica.tar.gz.sum256" ] && [ -f "/usr/src/friendica-addons.tar.gz.sum256" ] && \
+    cmp -s "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "/usr/src/friendica.tar.gz.sum256" && \
+    cmp -s "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "/usr/src/friendica-addons.tar.gz.sum256"; then
+     echo "Already latest sources - skipped download"
+  else
 
-  gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
+    echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
 
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
-  echo "Core sources (${FRIENDICA_VERSION}) verified"
+    # Removing the whole directory first
+    rm -fr /usr/src/friendica
+    export GNUPGHOME="$(mktemp -d)"
 
-  tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
-  rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
-  mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
-  echo "Core sources (${FRIENDICA_VERSION}) extracted"
+    gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
 
-  chmod 777 /usr/src/friendica/view/smarty3
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
+    echo "Core sources (${FRIENDICA_VERSION}) verified"
 
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
-  echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+    tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
+    rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
+    echo "Core sources (${FRIENDICA_VERSION}) extracted"
 
-  mkdir -p /usr/src/friendica/addon
-  tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
-  rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
-  echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+    chmod 777 /usr/src/friendica/view/smarty3
 
-  gpgconf --kill all
-  rm -rf "$GNUPGHOME"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
+    echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+
+    mkdir -p /usr/src/friendica/addon
+    tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
+    echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+
+    gpgconf --kill all
+    rm -rf "$GNUPGHOME"
+
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 /usr/src/friendica.tar.gz.sum256
+    mv -f /usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 /usr/src/friendica-addons.tar.gz.sum256
+  fi
 fi
 
 exec /entrypoint.sh "$@"

--- a/2021.09-rc/fpm-alpine/entrypoint-dev.sh
+++ b/2021.09-rc/fpm-alpine/entrypoint-dev.sh
@@ -3,38 +3,52 @@ set -eu
 
 # just check if we execute apache or php-fpm
 if (expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]) && [ "${FRIENDICA_DISABLE_UPGRADE:-false}" = "false" ]; then
-  echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
+  curl -fsSL -o "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"
+  curl -fsSL -o "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_ADDONS}.tar.gz.sum256"
 
-  # Removing the whole directory first
-  rm -fr /usr/src/friendica
-  export GNUPGHOME="$(mktemp -d)"
+  # Don't download already latest sources
+  if [ -f "/usr/src/friendica.tar.gz.sum256" ] && [ -f "/usr/src/friendica-addons.tar.gz.sum256" ] && \
+    cmp -s "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "/usr/src/friendica.tar.gz.sum256" && \
+    cmp -s "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "/usr/src/friendica-addons.tar.gz.sum256"; then
+     echo "Already latest sources - skipped download"
+  else
 
-  gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
+    echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
 
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
-  echo "Core sources (${FRIENDICA_VERSION}) verified"
+    # Removing the whole directory first
+    rm -fr /usr/src/friendica
+    export GNUPGHOME="$(mktemp -d)"
 
-  tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
-  rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
-  mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
-  echo "Core sources (${FRIENDICA_VERSION}) extracted"
+    gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
 
-  chmod 777 /usr/src/friendica/view/smarty3
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
+    echo "Core sources (${FRIENDICA_VERSION}) verified"
 
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
-  echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+    tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
+    rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
+    echo "Core sources (${FRIENDICA_VERSION}) extracted"
 
-  mkdir -p /usr/src/friendica/addon
-  tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
-  rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
-  echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+    chmod 777 /usr/src/friendica/view/smarty3
 
-  gpgconf --kill all
-  rm -rf "$GNUPGHOME"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
+    echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+
+    mkdir -p /usr/src/friendica/addon
+    tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
+    echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+
+    gpgconf --kill all
+    rm -rf "$GNUPGHOME"
+
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 /usr/src/friendica.tar.gz.sum256
+    mv -f /usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 /usr/src/friendica-addons.tar.gz.sum256
+  fi
 fi
 
 exec /entrypoint.sh "$@"

--- a/2021.09-rc/fpm/entrypoint-dev.sh
+++ b/2021.09-rc/fpm/entrypoint-dev.sh
@@ -3,38 +3,52 @@ set -eu
 
 # just check if we execute apache or php-fpm
 if (expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]) && [ "${FRIENDICA_DISABLE_UPGRADE:-false}" = "false" ]; then
-  echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
+  curl -fsSL -o "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"
+  curl -fsSL -o "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_ADDONS}.tar.gz.sum256"
 
-  # Removing the whole directory first
-  rm -fr /usr/src/friendica
-  export GNUPGHOME="$(mktemp -d)"
+  # Don't download already latest sources
+  if [ -f "/usr/src/friendica.tar.gz.sum256" ] && [ -f "/usr/src/friendica-addons.tar.gz.sum256" ] && \
+    cmp -s "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "/usr/src/friendica.tar.gz.sum256" && \
+    cmp -s "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "/usr/src/friendica-addons.tar.gz.sum256"; then
+     echo "Already latest sources - skipped download"
+  else
 
-  gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
+    echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
 
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
-  echo "Core sources (${FRIENDICA_VERSION}) verified"
+    # Removing the whole directory first
+    rm -fr /usr/src/friendica
+    export GNUPGHOME="$(mktemp -d)"
 
-  tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
-  rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
-  mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
-  echo "Core sources (${FRIENDICA_VERSION}) extracted"
+    gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
 
-  chmod 777 /usr/src/friendica/view/smarty3
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
+    echo "Core sources (${FRIENDICA_VERSION}) verified"
 
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
-  echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+    tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
+    rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
+    echo "Core sources (${FRIENDICA_VERSION}) extracted"
 
-  mkdir -p /usr/src/friendica/addon
-  tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
-  rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
-  echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+    chmod 777 /usr/src/friendica/view/smarty3
 
-  gpgconf --kill all
-  rm -rf "$GNUPGHOME"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
+    echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+
+    mkdir -p /usr/src/friendica/addon
+    tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
+    echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+
+    gpgconf --kill all
+    rm -rf "$GNUPGHOME"
+
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 /usr/src/friendica.tar.gz.sum256
+    mv -f /usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 /usr/src/friendica-addons.tar.gz.sum256
+  fi
 fi
 
 exec /entrypoint.sh "$@"

--- a/docker-entrypoint-dev.sh
+++ b/docker-entrypoint-dev.sh
@@ -3,38 +3,52 @@ set -eu
 
 # just check if we execute apache or php-fpm
 if (expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]) && [ "${FRIENDICA_DISABLE_UPGRADE:-false}" = "false" ]; then
-  echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
+  curl -fsSL -o "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256"
+  curl -fsSL -o "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "https://files.friendi.ca/friendica-full-${FRIENDICA_ADDONS}.tar.gz.sum256"
 
-  # Removing the whole directory first
-  rm -fr /usr/src/friendica
-  export GNUPGHOME="$(mktemp -d)"
+  # Don't download already latest sources
+  if [ -f "/usr/src/friendica.tar.gz.sum256" ] && [ -f "/usr/src/friendica-addons.tar.gz.sum256" ] && \
+    cmp -s "/usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256" "/usr/src/friendica.tar.gz.sum256" && \
+    cmp -s "/usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256" "/usr/src/friendica-addons.tar.gz.sum256"; then
+     echo "Already latest sources - skipped download"
+  else
 
-  gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
+    echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
 
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
-  curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
-  echo "Core sources (${FRIENDICA_VERSION}) verified"
+    # Removing the whole directory first
+    rm -fr /usr/src/friendica
+    export GNUPGHOME="$(mktemp -d)"
 
-  tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
-  rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
-  mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
-  echo "Core sources (${FRIENDICA_VERSION}) extracted"
+    gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
 
-  chmod 777 /usr/src/friendica/view/smarty3
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc";
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz
+    echo "Core sources (${FRIENDICA_VERSION}) verified"
 
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
-  curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
-  gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
-  echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+    tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
+    rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
+    echo "Core sources (${FRIENDICA_VERSION}) extracted"
 
-  mkdir -p /usr/src/friendica/addon
-  tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
-  rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
-  echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+    chmod 777 /usr/src/friendica/view/smarty3
 
-  gpgconf --kill all
-  rm -rf "$GNUPGHOME"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"
+    gpg --batch --logger-fd=1 --no-tty --quiet --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz
+    echo "Addon sources (${FRIENDICA_ADDONS}) verified"
+
+    mkdir -p /usr/src/friendica/addon
+    tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc
+    echo "Addon sources (${FRIENDICA_ADDONS}) extracted"
+
+    gpgconf --kill all
+    rm -rf "$GNUPGHOME"
+
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}.tar.gz.sum256 /usr/src/friendica.tar.gz.sum256
+    mv -f /usr/src/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.sum256 /usr/src/friendica-addons.tar.gz.sum256
+  fi
 fi
 
 exec /entrypoint.sh "$@"


### PR DESCRIPTION
We now store the latest sha256 of friendica/addons.

In case the latest sources are already in use, skip the download/checking process