### PR TITLE
Fix missing /usr/src/friendica/VERSION error

### DIFF
--- a/2022.03/apache/entrypoint.sh
+++ b/2022.03/apache/entrypoint.sh
@@ -74,7 +74,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="$(cat /var/www/html/VERSION)"
   fi
 
-  image_version="$(cat /usr/src/friendica/VERSION)"
+  image_version="0.0.0.0"
+  if [ -f /usr/src/friendica/VERSION ]; then
+    image_version="$(cat /usr/src/friendica/VERSION)"
+  else
+    echo "No new Friendica sources found (enable FRIENDICA_UPGRADE for new sources)"
+  fi
 
   # no downgrading possible
   if version_greater "$installed_version" "$image_version"; then

--- a/2022.03/fpm-alpine/entrypoint.sh
+++ b/2022.03/fpm-alpine/entrypoint.sh
@@ -74,7 +74,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="$(cat /var/www/html/VERSION)"
   fi
 
-  image_version="$(cat /usr/src/friendica/VERSION)"
+  image_version="0.0.0.0"
+  if [ -f /usr/src/friendica/VERSION ]; then
+    image_version="$(cat /usr/src/friendica/VERSION)"
+  else
+    echo "No new Friendica sources found (enable FRIENDICA_UPGRADE for new sources)"
+  fi
 
   # no downgrading possible
   if version_greater "$installed_version" "$image_version"; then

--- a/2022.03/fpm/entrypoint.sh
+++ b/2022.03/fpm/entrypoint.sh
@@ -74,7 +74,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="$(cat /var/www/html/VERSION)"
   fi
 
-  image_version="$(cat /usr/src/friendica/VERSION)"
+  image_version="0.0.0.0"
+  if [ -f /usr/src/friendica/VERSION ]; then
+    image_version="$(cat /usr/src/friendica/VERSION)"
+  else
+    echo "No new Friendica sources found (enable FRIENDICA_UPGRADE for new sources)"
+  fi
 
   # no downgrading possible
   if version_greater "$installed_version" "$image_version"; then

--- a/2022.06/apache/entrypoint.sh
+++ b/2022.06/apache/entrypoint.sh
@@ -74,7 +74,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="$(cat /var/www/html/VERSION)"
   fi
 
-  image_version="$(cat /usr/src/friendica/VERSION)"
+  image_version="0.0.0.0"
+  if [ -f /usr/src/friendica/VERSION ]; then
+    image_version="$(cat /usr/src/friendica/VERSION)"
+  else
+    echo "No new Friendica sources found (enable FRIENDICA_UPGRADE for new sources)"
+  fi
 
   # no downgrading possible
   if version_greater "$installed_version" "$image_version"; then

--- a/2022.06/fpm-alpine/entrypoint.sh
+++ b/2022.06/fpm-alpine/entrypoint.sh
@@ -74,7 +74,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="$(cat /var/www/html/VERSION)"
   fi
 
-  image_version="$(cat /usr/src/friendica/VERSION)"
+  image_version="0.0.0.0"
+  if [ -f /usr/src/friendica/VERSION ]; then
+    image_version="$(cat /usr/src/friendica/VERSION)"
+  else
+    echo "No new Friendica sources found (enable FRIENDICA_UPGRADE for new sources)"
+  fi
 
   # no downgrading possible
   if version_greater "$installed_version" "$image_version"; then

--- a/2022.06/fpm/entrypoint.sh
+++ b/2022.06/fpm/entrypoint.sh
@@ -74,7 +74,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="$(cat /var/www/html/VERSION)"
   fi
 
-  image_version="$(cat /usr/src/friendica/VERSION)"
+  image_version="0.0.0.0"
+  if [ -f /usr/src/friendica/VERSION ]; then
+    image_version="$(cat /usr/src/friendica/VERSION)"
+  else
+    echo "No new Friendica sources found (enable FRIENDICA_UPGRADE for new sources)"
+  fi
 
   # no downgrading possible
   if version_greater "$installed_version" "$image_version"; then

--- a/2022.09-dev/apache/entrypoint.sh
+++ b/2022.09-dev/apache/entrypoint.sh
@@ -74,7 +74,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="$(cat /var/www/html/VERSION)"
   fi
 
-  image_version="$(cat /usr/src/friendica/VERSION)"
+  image_version="0.0.0.0"
+  if [ -f /usr/src/friendica/VERSION ]; then
+    image_version="$(cat /usr/src/friendica/VERSION)"
+  else
+    echo "No new Friendica sources found (enable FRIENDICA_UPGRADE for new sources)"
+  fi
 
   # no downgrading possible
   if version_greater "$installed_version" "$image_version"; then

--- a/2022.09-dev/fpm-alpine/entrypoint.sh
+++ b/2022.09-dev/fpm-alpine/entrypoint.sh
@@ -74,7 +74,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="$(cat /var/www/html/VERSION)"
   fi
 
-  image_version="$(cat /usr/src/friendica/VERSION)"
+  image_version="0.0.0.0"
+  if [ -f /usr/src/friendica/VERSION ]; then
+    image_version="$(cat /usr/src/friendica/VERSION)"
+  else
+    echo "No new Friendica sources found (enable FRIENDICA_UPGRADE for new sources)"
+  fi
 
   # no downgrading possible
   if version_greater "$installed_version" "$image_version"; then

--- a/2022.09-dev/fpm/entrypoint.sh
+++ b/2022.09-dev/fpm/entrypoint.sh
@@ -74,7 +74,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="$(cat /var/www/html/VERSION)"
   fi
 
-  image_version="$(cat /usr/src/friendica/VERSION)"
+  image_version="0.0.0.0"
+  if [ -f /usr/src/friendica/VERSION ]; then
+    image_version="$(cat /usr/src/friendica/VERSION)"
+  else
+    echo "No new Friendica sources found (enable FRIENDICA_UPGRADE for new sources)"
+  fi
 
   # no downgrading possible
   if version_greater "$installed_version" "$image_version"; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -74,7 +74,12 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     installed_version="$(cat /var/www/html/VERSION)"
   fi
 
-  image_version="$(cat /usr/src/friendica/VERSION)"
+  image_version="0.0.0.0"
+  if [ -f /usr/src/friendica/VERSION ]; then
+    image_version="$(cat /usr/src/friendica/VERSION)"
+  else
+    echo "No new Friendica sources found (enable FRIENDICA_UPGRADE for new sources)"
+  fi
 
   # no downgrading possible
   if version_greater "$installed_version" "$image_version"; then


### PR DESCRIPTION
Fixes https://github.com/friendica/friendica/issues/11511#issuecomment-1146775897

This occurs when a develop-/rc-container gets restarted without the `FRIENDICA_UPGRADE` flag, so no sources are packaged directly into the image nor is fetching the sources per upgrade allowed -> `/usr/src/friendica` remains empty :)