### PR TITLE
Add GNU Multiple Precision PHP module

### DIFF
--- a/2022.10/apache/Dockerfile
+++ b/2022.10/apache/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex; \
         librsvg2-2 \
         libzip-dev \
         libldap2-dev \
+        libgmp-dev \
     ; \
     \
         debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
@@ -90,6 +91,7 @@ RUN set -ex; \
         ctype \
         pcntl \
         ldap \
+        gmp \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately

--- a/2022.10/fpm-alpine/Dockerfile
+++ b/2022.10/fpm-alpine/Dockerfile
@@ -60,6 +60,7 @@ RUN set -ex; \
         libzip-dev \
         icu-dev \
         openldap-dev \
+        gmp-dev \
     ; \
     \
     docker-php-ext-configure gd \
@@ -76,6 +77,7 @@ RUN set -ex; \
         opcache \
         pcntl \
         ldap \
+        gmp \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately

--- a/2022.10/fpm/Dockerfile
+++ b/2022.10/fpm/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex; \
         librsvg2-2 \
         libzip-dev \
         libldap2-dev \
+        libgmp-dev \
     ; \
     \
         debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
@@ -90,6 +91,7 @@ RUN set -ex; \
         ctype \
         pcntl \
         ldap \
+        gmp \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately

--- a/2022.12-dev/apache/Dockerfile
+++ b/2022.12-dev/apache/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex; \
         librsvg2-2 \
         libzip-dev \
         libldap2-dev \
+        libgmp-dev \
     ; \
     \
         debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
@@ -90,6 +91,7 @@ RUN set -ex; \
         ctype \
         pcntl \
         ldap \
+        gmp \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately

--- a/2022.12-dev/fpm-alpine/Dockerfile
+++ b/2022.12-dev/fpm-alpine/Dockerfile
@@ -60,6 +60,7 @@ RUN set -ex; \
         libzip-dev \
         icu-dev \
         openldap-dev \
+        gmp-dev \
     ; \
     \
     docker-php-ext-configure gd \
@@ -76,6 +77,7 @@ RUN set -ex; \
         opcache \
         pcntl \
         ldap \
+        gmp \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately

--- a/2022.12-dev/fpm/Dockerfile
+++ b/2022.12-dev/fpm/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex; \
         librsvg2-2 \
         libzip-dev \
         libldap2-dev \
+        libgmp-dev \
     ; \
     \
         debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
@@ -90,6 +91,7 @@ RUN set -ex; \
         ctype \
         pcntl \
         ldap \
+        gmp \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -59,6 +59,7 @@ RUN set -ex; \
         libzip-dev \
         icu-dev \
         openldap-dev \
+        gmp-dev \
     ; \
     \
     docker-php-ext-configure gd \
@@ -75,6 +76,7 @@ RUN set -ex; \
         opcache \
         pcntl \
         ldap \
+        gmp \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -68,6 +68,7 @@ RUN set -ex; \
         librsvg2-2 \
         libzip-dev \
         libldap2-dev \
+        libgmp-dev \
     ; \
     \
         debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
@@ -89,6 +90,7 @@ RUN set -ex; \
         ctype \
         pcntl \
         ldap \
+        gmp \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately


### PR DESCRIPTION
Fixes #211 
Caused by https://github.com/friendica/friendica/pull/11746

Thank you @Jeffmackinnon for finding it!
The `libgmp-dev` dependency was just part of the whole truth :) We also need to install the corresponding PHP extension to fully work