### PR TITLE
Update Friendica to php 8.0

### DIFF
--- a/2022.10/apache/Dockerfile
+++ b/2022.10/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:7.4-apache-bullseye
+FROM php:8.0-apache-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2022.10/apache/Dockerfile
+++ b/2022.10/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.0-apache-bullseye
+FROM php:7.4-apache-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2022.10/fpm-alpine/Dockerfile
+++ b/2022.10/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:7.4-fpm-alpine
+FROM php:8.0-fpm-alpine
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2022.10/fpm-alpine/Dockerfile
+++ b/2022.10/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:8.0-fpm-alpine
+FROM php:7.4-fpm-alpine
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2022.10/fpm/Dockerfile
+++ b/2022.10/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:7.4-fpm-bullseye
+FROM php:8.0-fpm-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2022.10/fpm/Dockerfile
+++ b/2022.10/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.0-fpm-bullseye
+FROM php:7.4-fpm-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2022.12-dev/apache/Dockerfile
+++ b/2022.12-dev/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:7.4-apache-bullseye
+FROM php:8.0-apache-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2022.12-dev/fpm-alpine/Dockerfile
+++ b/2022.12-dev/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:7.4-fpm-alpine
+FROM php:8.0-fpm-alpine
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2022.12-dev/fpm/Dockerfile
+++ b/2022.12-dev/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:7.4-fpm-bullseye
+FROM php:8.0-fpm-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 declare -A php_version=(
-  [default]='7.4'
+  [default]='8.0'
 )
 
 declare -A cmd=(

--- a/update.sh
+++ b/update.sh
@@ -2,6 +2,7 @@
 set -eo pipefail
 
 declare -A php_version=(
+  [2022.10]='7.4'
   [default]='8.0'
 )
 

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,6 @@
 set -eo pipefail
 
 declare -A php_version=(
-  [2022.10]='7.4'
   [default]='8.0'
 )
 


### PR DESCRIPTION
addresses https://github.com/docker-library/official-images/pull/13622#issuecomment-1332695940

@MrPetovan - What do you say? Are we php8.0 ready? I know there're 8.1 issues left, but 8.0 should work, shouldn't it?