### PR TITLE
Make msmtp log to stdout to not show permission denied message

### DIFF
--- a/2023.01/apache/setup_msmtp.sh
+++ b/2023.01/apache/setup_msmtp.sh
@@ -30,7 +30,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
-    echo "logfile /var/log/msmtp.log"
+    echo "logfile -"
     echo "aliases /etc/aliases"
   } >/etc/msmtprc
 

--- a/2023.01/fpm-alpine/setup_msmtp.sh
+++ b/2023.01/fpm-alpine/setup_msmtp.sh
@@ -30,7 +30,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
-    echo "logfile /var/log/msmtp.log"
+    echo "logfile -"
     echo "aliases /etc/aliases"
   } >/etc/msmtprc
 

--- a/2023.01/fpm/setup_msmtp.sh
+++ b/2023.01/fpm/setup_msmtp.sh
@@ -30,7 +30,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
-    echo "logfile /var/log/msmtp.log"
+    echo "logfile -"
     echo "aliases /etc/aliases"
   } >/etc/msmtprc
 

--- a/2023.03-dev/apache/setup_msmtp.sh
+++ b/2023.03-dev/apache/setup_msmtp.sh
@@ -30,7 +30,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
-    echo "logfile /var/log/msmtp.log"
+    echo "logfile -"
     echo "aliases /etc/aliases"
   } >/etc/msmtprc
 

--- a/2023.03-dev/fpm-alpine/setup_msmtp.sh
+++ b/2023.03-dev/fpm-alpine/setup_msmtp.sh
@@ -30,7 +30,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
-    echo "logfile /var/log/msmtp.log"
+    echo "logfile -"
     echo "aliases /etc/aliases"
   } >/etc/msmtprc
 

--- a/2023.03-dev/fpm/setup_msmtp.sh
+++ b/2023.03-dev/fpm/setup_msmtp.sh
@@ -30,7 +30,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
-    echo "logfile /var/log/msmtp.log"
+    echo "logfile -"
     echo "aliases /etc/aliases"
   } >/etc/msmtprc
 

--- a/docker-setup_msmtp.sh
+++ b/docker-setup_msmtp.sh
@@ -30,7 +30,7 @@ if [ -n "${SMTP_DOMAIN+x}" ] && [ -n "${SMTP+x}" ] && [ "${SMTP}" != "localhost"
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "auth $smtp_auth"; fi
     if [ -n "${SMTP_AUTH_USER+x}" ]; then echo "user \"$SMTP_AUTH_USER\""; fi
     if [ -n "${SMTP_AUTH_PASS+x}" ]; then echo "password \"$SMTP_AUTH_PASS\""; fi
-    echo "logfile /var/log/msmtp.log"
+    echo "logfile -"
     echo "aliases /etc/aliases"
   } >/etc/msmtprc
 


### PR DESCRIPTION
Currently it will show permission denied message since the log file isn't created and will log to stdout anyway - since this is Docker, I think it's preferrable to log to stdout to keep things simple.