### PR TITLE
Update to PHP 8.1

### DIFF
--- a/2023.05/apache/Dockerfile
+++ b/2023.05/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.0-apache-bullseye
+FROM php:8.1-apache-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2023.05/fpm-alpine/Dockerfile
+++ b/2023.05/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:8.0-fpm-alpine
+FROM php:8.1-fpm-alpine
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2023.05/fpm/Dockerfile
+++ b/2023.05/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.0-fpm-bullseye
+FROM php:8.1-fpm-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2023.09-dev/apache/Dockerfile
+++ b/2023.09-dev/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.0-apache-bullseye
+FROM php:8.1-apache-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2023.09-dev/fpm-alpine/Dockerfile
+++ b/2023.09-dev/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:8.0-fpm-alpine
+FROM php:8.1-fpm-alpine
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2023.09-dev/fpm/Dockerfile
+++ b/2023.09-dev/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.0-fpm-bullseye
+FROM php:8.1-fpm-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2023.09-rc/apache/Dockerfile
+++ b/2023.09-rc/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.0-apache-bullseye
+FROM php:8.1-apache-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2023.09-rc/fpm-alpine/Dockerfile
+++ b/2023.09-rc/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:8.0-fpm-alpine
+FROM php:8.1-fpm-alpine
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2023.09-rc/fpm/Dockerfile
+++ b/2023.09-rc/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.0-fpm-bullseye
+FROM php:8.1-fpm-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 declare -A php_version=(
-  [default]='8.0'
+  [default]='8.1'
 )
 
 declare -A cmd=(


### PR DESCRIPTION
PHP 8.0 was removed from Docker  - have a look at https://github.com/docker-library/official-images/pull/15804

So we now switch to PHP 8.1 as well

Pinging @MrPetovan for merging plz :)