### PR TITLE
Revert Debian to bullseye

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,4 +1,4 @@
-FROM php:%%PHP_VERSION%%-%%VARIANT%%-bookworm
+FROM php:%%PHP_VERSION%%-%%VARIANT%%-bullseye
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \


### PR DESCRIPTION
Fixes #261

I don't get what the problem is with the last version based on bookworm. For now we should revert to bullseye until this is solved.