### PR TITLE
Continuation of #271. Fix git add command ...

### DIFF
--- a/.github/workflows/update-sh.yml
+++ b/.github/workflows/update-sh.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           git config --local user.email "workflow@github.com"
           git config --local user.name "GitHub Workflow"
-          git add ./*
+          git add .
           git commit -m "Runs update.sh" || echo "Nothing to update"
       - name: Push changes
         uses: ad-m/github-push-action@master


### PR DESCRIPTION
to take deleted directories into account.

`git add ./*` does not detect deleted folders. Using `git add .` fixes this.