### PR TITLE
Complete the automatic (cli) install process

### DIFF
--- a/2025.02-dev/apache/entrypoint.sh
+++ b/2025.02-dev/apache/entrypoint.sh
@@ -149,6 +149,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
           # shellcheck disable=SC2016
           install_options=$install_options' --admin "'$FRIENDICA_ADMIN_MAIL'" --tz "'$FRIENDICA_TZ'" --lang "'$FRIENDICA_LANG'" --url "'$FRIENDICA_URL'"'
           install=true
+          install=true
+        else
+          echo "One or more environment variable is not set, skipping automated installation"
         fi
 
         if [ "$install" = true ]; then
@@ -165,6 +168,18 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
               rsync $rsync_options --ignore-existing /usr/src/friendica/config/ /var/www/html/config/
             fi
 
+            # Add the administrator account
+            changeme=`head -c 30 /dev/urandom | base64`
+            FRIENDICA_ADMIN_NICKNAME=`echo $FRIENDICA_ADMIN_MAIL | sed 's/@.*//'`
+            echo " "
+            echo "Adding the administrator account named: $FRIENDICA_ADMIN_NICKNAME"
+            run_as "php /var/www/html/bin/console.php user add $FRIENDICA_ADMIN_NICKNAME $FRIENDICA_ADMIN_NICKNAME $FRIENDICA_ADMIN_MAIL EN $FRIENDICA_URL/images/person-300.jpg"
+            echo "Setting password"
+            run_as "php /var/www/html/bin/console.php user password $FRIENDICA_ADMIN_NICKNAME $changeme"
+            echo " "
+            echo "YOUR ADMINISTRATOR PASSWORD IS: $changeme"
+            echo "NOTE IT DOWN AND CHANGE IT ON FIRST LOGIN"
+            echo " "
             echo "Installation finished"
           else
             echo "[ERROR] Waited 300 seconds, no response" >&2
@@ -178,6 +193,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         run_as 'php /var/www/html/bin/console.php dbstructure update -f'
         echo "Upgrading finished"
       fi
+
     fi
   ) 9> /var/www/html/friendica-init-sync.lock
 fi

--- a/2025.02-dev/apache/entrypoint.sh
+++ b/2025.02-dev/apache/entrypoint.sh
@@ -192,7 +192,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         run_as 'php /var/www/html/bin/console.php dbstructure update -f'
         echo "Upgrading finished"
       fi
-
     fi
   ) 9> /var/www/html/friendica-init-sync.lock
 fi

--- a/2025.02-dev/apache/entrypoint.sh
+++ b/2025.02-dev/apache/entrypoint.sh
@@ -149,7 +149,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
           # shellcheck disable=SC2016
           install_options=$install_options' --admin "'$FRIENDICA_ADMIN_MAIL'" --tz "'$FRIENDICA_TZ'" --lang "'$FRIENDICA_LANG'" --url "'$FRIENDICA_URL'"'
           install=true
-          install=true
         else
           echo "One or more environment variable is not set, skipping automated installation"
         fi

--- a/2025.02-dev/fpm-alpine/entrypoint.sh
+++ b/2025.02-dev/fpm-alpine/entrypoint.sh
@@ -149,6 +149,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
           # shellcheck disable=SC2016
           install_options=$install_options' --admin "'$FRIENDICA_ADMIN_MAIL'" --tz "'$FRIENDICA_TZ'" --lang "'$FRIENDICA_LANG'" --url "'$FRIENDICA_URL'"'
           install=true
+          install=true
+        else
+          echo "One or more environment variable is not set, skipping automated installation"
         fi
 
         if [ "$install" = true ]; then
@@ -165,6 +168,18 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
               rsync $rsync_options --ignore-existing /usr/src/friendica/config/ /var/www/html/config/
             fi
 
+            # Add the administrator account
+            changeme=`head -c 30 /dev/urandom | base64`
+            FRIENDICA_ADMIN_NICKNAME=`echo $FRIENDICA_ADMIN_MAIL | sed 's/@.*//'`
+            echo " "
+            echo "Adding the administrator account named: $FRIENDICA_ADMIN_NICKNAME"
+            run_as "php /var/www/html/bin/console.php user add $FRIENDICA_ADMIN_NICKNAME $FRIENDICA_ADMIN_NICKNAME $FRIENDICA_ADMIN_MAIL EN $FRIENDICA_URL/images/person-300.jpg"
+            echo "Setting password"
+            run_as "php /var/www/html/bin/console.php user password $FRIENDICA_ADMIN_NICKNAME $changeme"
+            echo " "
+            echo "YOUR ADMINISTRATOR PASSWORD IS: $changeme"
+            echo "NOTE IT DOWN AND CHANGE IT ON FIRST LOGIN"
+            echo " "
             echo "Installation finished"
           else
             echo "[ERROR] Waited 300 seconds, no response" >&2
@@ -178,6 +193,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         run_as 'php /var/www/html/bin/console.php dbstructure update -f'
         echo "Upgrading finished"
       fi
+
     fi
   ) 9> /var/www/html/friendica-init-sync.lock
 fi

--- a/2025.02-dev/fpm-alpine/entrypoint.sh
+++ b/2025.02-dev/fpm-alpine/entrypoint.sh
@@ -193,7 +193,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         run_as 'php /var/www/html/bin/console.php dbstructure update -f'
         echo "Upgrading finished"
       fi
-
     fi
   ) 9> /var/www/html/friendica-init-sync.lock
 fi

--- a/2025.02-dev/fpm-alpine/entrypoint.sh
+++ b/2025.02-dev/fpm-alpine/entrypoint.sh
@@ -149,7 +149,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
           # shellcheck disable=SC2016
           install_options=$install_options' --admin "'$FRIENDICA_ADMIN_MAIL'" --tz "'$FRIENDICA_TZ'" --lang "'$FRIENDICA_LANG'" --url "'$FRIENDICA_URL'"'
           install=true
-          install=true
         else
           echo "One or more environment variable is not set, skipping automated installation"
         fi

--- a/2025.02-dev/fpm/entrypoint.sh
+++ b/2025.02-dev/fpm/entrypoint.sh
@@ -149,6 +149,9 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
           # shellcheck disable=SC2016
           install_options=$install_options' --admin "'$FRIENDICA_ADMIN_MAIL'" --tz "'$FRIENDICA_TZ'" --lang "'$FRIENDICA_LANG'" --url "'$FRIENDICA_URL'"'
           install=true
+          install=true
+        else
+          echo "One or more environment variable is not set, skipping automated installation"
         fi
 
         if [ "$install" = true ]; then
@@ -165,6 +168,18 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
               rsync $rsync_options --ignore-existing /usr/src/friendica/config/ /var/www/html/config/
             fi
 
+            # Add the administrator account
+            changeme=`head -c 30 /dev/urandom | base64`
+            FRIENDICA_ADMIN_NICKNAME=`echo $FRIENDICA_ADMIN_MAIL | sed 's/@.*//'`
+            echo " "
+            echo "Adding the administrator account named: $FRIENDICA_ADMIN_NICKNAME"
+            run_as "php /var/www/html/bin/console.php user add $FRIENDICA_ADMIN_NICKNAME $FRIENDICA_ADMIN_NICKNAME $FRIENDICA_ADMIN_MAIL EN $FRIENDICA_URL/images/person-300.jpg"
+            echo "Setting password"
+            run_as "php /var/www/html/bin/console.php user password $FRIENDICA_ADMIN_NICKNAME $changeme"
+            echo " "
+            echo "YOUR ADMINISTRATOR PASSWORD IS: $changeme"
+            echo "NOTE IT DOWN AND CHANGE IT ON FIRST LOGIN"
+            echo " "
             echo "Installation finished"
           else
             echo "[ERROR] Waited 300 seconds, no response" >&2
@@ -178,6 +193,7 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         run_as 'php /var/www/html/bin/console.php dbstructure update -f'
         echo "Upgrading finished"
       fi
+
     fi
   ) 9> /var/www/html/friendica-init-sync.lock
 fi

--- a/2025.02-dev/fpm/entrypoint.sh
+++ b/2025.02-dev/fpm/entrypoint.sh
@@ -193,7 +193,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
         run_as 'php /var/www/html/bin/console.php dbstructure update -f'
         echo "Upgrading finished"
       fi
-
     fi
   ) 9> /var/www/html/friendica-init-sync.lock
 fi

--- a/2025.02-dev/fpm/entrypoint.sh
+++ b/2025.02-dev/fpm/entrypoint.sh
@@ -149,7 +149,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
           # shellcheck disable=SC2016
           install_options=$install_options' --admin "'$FRIENDICA_ADMIN_MAIL'" --tz "'$FRIENDICA_TZ'" --lang "'$FRIENDICA_LANG'" --url "'$FRIENDICA_URL'"'
           install=true
-          install=true
         else
           echo "One or more environment variable is not set, skipping automated installation"
         fi

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Note that you may have to change other limits depending on your client, webserve
 
 ## Administrator account
 
-Because Friendica links the administrator account to a specific mail address, you **have** to set a valid address for `MAILNAME`.
+Because Friendica links the administrator account to a specific mail address, you **have** to set a valid address for `FRIENDICA_ADMIN_MAIL`.
 
 ## Mail settings
 
@@ -179,6 +179,9 @@ To enable the automatic installation, you have to the following environment vari
 -	`MYSQL_PASSWORD` Password for the database user using mysql / mariadb.
 -	`MYSQL_DATABASE` Name of the database using mysql / mariadb.
 -	`MYSQL_HOST` Hostname of the database server using mysql / mariadb.
+
+**During the first run, you will be given the `FRIENDICA_ADMIN_MAIL` administrator's account first random password.**
+**It is important to note it down and change it after first login.**
 
 # Docker Secrets
 As an alternative to passing sensitive information via environment variables, _FILE may be appended to the previously listed environment variables, causing the initialization script to load the values for those variables from files present in the container.


### PR DESCRIPTION
Hello there,

I am giving Friendica a try on Linux + Docker.

It seems other admins have difficulties setting up a new instance from scratch.

1.  The automatic install using command line only is incomplete, this PR proposes a solution about that:
When desired environment variables are set, don't leave the install halfway, the [doc says "Automatic installation"](https://github.com/friendica/docker?tab=readme-ov-file#automatic-installation) it should leave the instance in a usable state right away. Otherwise the admin fallbacks to the WebUI install wizard.
It may fix issues like #134 

1. The WebUI install (wizard) is stuck in a loop, as #266 I have a similar problem.
But at this time this is above my skills to help about that.

Hope it helps