### PR TITLE
Prevent deleting the files in /config when downloading newest sources

### DIFF
--- a/docker-entrypoint-dev.sh
+++ b/docker-entrypoint-dev.sh
@@ -15,8 +15,8 @@ if (expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]) && [ "${FRIENDICA_
 
     echo "Download sources for ${FRIENDICA_VERSION} (Addon: ${FRIENDICA_ADDONS})"
 
-    # Removing the whole directory first
-    rm -fr /usr/src/friendica
+    # Removing the previous sources (except config) first
+    find /usr/src/friendica -mindepth 1 -maxdepth 1 ! -name 'config' -exec rm -rf {} +
     export GNUPGHOME="$(mktemp -d)"
 
     gpg --batch --logger-fd=1 --no-tty --quiet --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287
@@ -28,6 +28,8 @@ if (expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]) && [ "${FRIENDICA_
 
     tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/
     rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc
+    cp -an /usr/src/friendica/config/* /usr/src/friendica-full-${FRIENDICA_VERSION}/config/    
+    rm -fr /usr/src/friendica
     mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica
     echo "Core sources (${FRIENDICA_VERSION}) extracted"
 


### PR DESCRIPTION

Fixes #279 

This PR prevents the deleting of the extra config files in /config folder (e.g. 00apcu.config.php) that are provided by the docker image but are not part of the sources tar ball. 
The fix only affects dev and rc versions of the docker image (the release versions didn't have this problem).