### PR TITLE
Make update.sh more readable

### DIFF
--- a/2024.08/apache/Dockerfile
+++ b/2024.08/apache/Dockerfile
@@ -155,17 +155,17 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+RUN set -ex; \
+    a2enmod rewrite remoteip; \
+    { \
+     echo RemoteIPHeader X-Real-IP; \
+     echo RemoteIPTrustedProxy 10.0.0.0/8; \
+     echo RemoteIPTrustedProxy 172.16.0.0/12; \
+     echo RemoteIPTrustedProxy 192.168.0.0/16; \
+    } > /etc/apache2/conf-available/remoteip.conf; \
+    a2enconf remoteip;
 
-RUN set -ex;\
-    a2enmod rewrite remoteip ;\
-    {\
-     echo RemoteIPHeader X-Real-IP ;\
-     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
-     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
-     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
-    } > /etc/apache2/conf-available/remoteip.conf;\
-    a2enconf remoteip
+VOLUME /var/www/html
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39
@@ -196,9 +196,9 @@ RUN set -ex; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
-            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc \
-            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
     gpg --batch --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
     echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" | sha256sum -c; \
     mkdir -p /usr/src/friendica/proxy; \

--- a/2024.08/fpm-alpine/Dockerfile
+++ b/2024.08/fpm-alpine/Dockerfile
@@ -134,8 +134,9 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
 
+
+VOLUME /var/www/html
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39
@@ -145,10 +146,10 @@ ENV FRIENDICA_DOWNLOAD_SHA256 "3e93178734bc82abd0c7c8b8b7c13baa4c18ae33a0f07c169
 ENV FRIENDICA_DOWNLOAD_ADDONS_SHA256 "748d399f64670e37a5afc94ef65483291c52e9374e26c0ee5235f91b55449f54"
 
 RUN set -ex; \
-     apk add --no-cache --virtual .fetch-deps \
-            gnupg \
-        ; \
-        \
+    apk add --no-cache --virtual .fetch-deps \
+      gnupg \
+    ; \
+    \
     export GNUPGHOME="$(mktemp -d)"; \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287; \
     \
@@ -164,9 +165,9 @@ RUN set -ex; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
-            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc \
-            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
     gpg --batch --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
     echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" | sha256sum -c; \
     mkdir -p /usr/src/friendica/proxy; \

--- a/2024.08/fpm/Dockerfile
+++ b/2024.08/fpm/Dockerfile
@@ -155,8 +155,9 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
 
+
+VOLUME /var/www/html
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39
@@ -187,9 +188,9 @@ RUN set -ex; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
-            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc \
-            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
     gpg --batch --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
     echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" | sha256sum -c; \
     mkdir -p /usr/src/friendica/proxy; \

--- a/2024.12/apache/Dockerfile
+++ b/2024.12/apache/Dockerfile
@@ -155,17 +155,17 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+RUN set -ex; \
+    a2enmod rewrite remoteip; \
+    { \
+     echo RemoteIPHeader X-Real-IP; \
+     echo RemoteIPTrustedProxy 10.0.0.0/8; \
+     echo RemoteIPTrustedProxy 172.16.0.0/12; \
+     echo RemoteIPTrustedProxy 192.168.0.0/16; \
+    } > /etc/apache2/conf-available/remoteip.conf; \
+    a2enconf remoteip;
 
-RUN set -ex;\
-    a2enmod rewrite remoteip ;\
-    {\
-     echo RemoteIPHeader X-Real-IP ;\
-     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
-     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
-     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
-    } > /etc/apache2/conf-available/remoteip.conf;\
-    a2enconf remoteip
+VOLUME /var/www/html
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39
@@ -196,9 +196,9 @@ RUN set -ex; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
-            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc \
-            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
     gpg --batch --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
     echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" | sha256sum -c; \
     mkdir -p /usr/src/friendica/proxy; \

--- a/2024.12/fpm-alpine/Dockerfile
+++ b/2024.12/fpm-alpine/Dockerfile
@@ -134,8 +134,9 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
 
+
+VOLUME /var/www/html
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39
@@ -145,10 +146,10 @@ ENV FRIENDICA_DOWNLOAD_SHA256 "37bb0fad549c955fced70059b62cd4f3364e344363011a2d0
 ENV FRIENDICA_DOWNLOAD_ADDONS_SHA256 "fbbece635dfaec9d2365581aaafb913cec00128e5815087c9d9b8a46d8dc7ed5"
 
 RUN set -ex; \
-     apk add --no-cache --virtual .fetch-deps \
-            gnupg \
-        ; \
-        \
+    apk add --no-cache --virtual .fetch-deps \
+      gnupg \
+    ; \
+    \
     export GNUPGHOME="$(mktemp -d)"; \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287; \
     \
@@ -164,9 +165,9 @@ RUN set -ex; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
-            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc \
-            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
     gpg --batch --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
     echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" | sha256sum -c; \
     mkdir -p /usr/src/friendica/proxy; \

--- a/2024.12/fpm/Dockerfile
+++ b/2024.12/fpm/Dockerfile
@@ -155,8 +155,9 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
 
+
+VOLUME /var/www/html
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39
@@ -187,9 +188,9 @@ RUN set -ex; \
     chmod 777 /usr/src/friendica/view/smarty3; \
     \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
-            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
     curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc \
-            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
     gpg --batch --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
     echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" | sha256sum -c; \
     mkdir -p /usr/src/friendica/proxy; \

--- a/2025.02-dev/apache/Dockerfile
+++ b/2025.02-dev/apache/Dockerfile
@@ -155,26 +155,27 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
+RUN set -ex; \
+    a2enmod rewrite remoteip; \
+    { \
+     echo RemoteIPHeader X-Real-IP; \
+     echo RemoteIPTrustedProxy 10.0.0.0/8; \
+     echo RemoteIPTrustedProxy 172.16.0.0/12; \
+     echo RemoteIPTrustedProxy 192.168.0.0/16; \
+    } > /etc/apache2/conf-available/remoteip.conf; \
+    a2enconf remoteip;
 
-RUN set -ex;\
-    a2enmod rewrite remoteip ;\
-    {\
-     echo RemoteIPHeader X-Real-IP ;\
-     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
-     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
-     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
-    } > /etc/apache2/conf-available/remoteip.conf;\
-    a2enconf remoteip
+VOLUME /var/www/html
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39
 ENV FRIENDICA_VERSION "2025.02-dev"
 ENV FRIENDICA_ADDONS "2025.02-dev"
 
+
 RUN set -ex; \
     fetchDeps=" \
-        gnupg \
+      gnupg \
     "; \
     apt-get update; \
     apt-get install -y --no-install-recommends $fetchDeps;

--- a/2025.02-dev/fpm-alpine/Dockerfile
+++ b/2025.02-dev/fpm-alpine/Dockerfile
@@ -134,18 +134,20 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
 
+
+VOLUME /var/www/html
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39
 ENV FRIENDICA_VERSION "2025.02-dev"
 ENV FRIENDICA_ADDONS "2025.02-dev"
 
+
 RUN set -ex; \
-     apk add --no-cache --virtual .fetch-deps \
-            gnupg \
-        ;
+    apk add --no-cache --virtual .fetch-deps \
+      gnupg \
+    ;
 
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/friendica/config/

--- a/2025.02-dev/fpm/Dockerfile
+++ b/2025.02-dev/fpm/Dockerfile
@@ -155,17 +155,19 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
 
+
+VOLUME /var/www/html
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39
 ENV FRIENDICA_VERSION "2025.02-dev"
 ENV FRIENDICA_ADDONS "2025.02-dev"
 
+
 RUN set -ex; \
     fetchDeps=" \
-        gnupg \
+      gnupg \
     "; \
     apt-get update; \
     apt-get install -y --no-install-recommends $fetchDeps;

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -133,15 +133,18 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
 %%VARIANT_EXTRAS%%
+
+VOLUME /var/www/html
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39
 ENV FRIENDICA_VERSION "%%VERSION%%"
 ENV FRIENDICA_ADDONS "%%VERSION%%"
 %%DOWNLOAD_SHA256%%
+
 %%INSTALL_EXTRAS%%
+
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/friendica/config/
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -154,15 +154,18 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-VOLUME /var/www/html
 %%VARIANT_EXTRAS%%
+
+VOLUME /var/www/html
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39
 ENV FRIENDICA_VERSION "%%VERSION%%"
 ENV FRIENDICA_ADDONS "%%VERSION%%"
 %%DOWNLOAD_SHA256%%
+
 %%INSTALL_EXTRAS%%
+
 COPY *.sh upgrade.exclude /
 COPY config/* /usr/src/friendica/config/
 

--- a/update.sh
+++ b/update.sh
@@ -18,7 +18,15 @@ declare -A base=(
 )
 
 declare -A extras=(
-  [apache]='\nRUN set -ex;\\\n    a2enmod rewrite remoteip ;\\\n    {\\\n     echo RemoteIPHeader X-Real-IP ;\\\n     echo RemoteIPTrustedProxy 10.0.0.0/8 ;\\\n     echo RemoteIPTrustedProxy 172.16.0.0/12 ;\\\n     echo RemoteIPTrustedProxy 192.168.0.0/16 ;\\\n    } > /etc/apache2/conf-available/remoteip.conf;\\\n    a2enconf remoteip'
+  [apache]='RUN set -ex; \
+    a2enmod rewrite remoteip; \
+    { \
+     echo RemoteIPHeader X-Real-IP; \
+     echo RemoteIPTrustedProxy 10.0.0.0/8; \
+     echo RemoteIPTrustedProxy 172.16.0.0/12; \
+     echo RemoteIPTrustedProxy 192.168.0.0/16; \
+    } > /etc/apache2/conf-available/remoteip.conf; \
+    a2enconf remoteip;'
   [fpm]=''
   [fpm-alpine]=''
 )
@@ -83,10 +91,87 @@ declare -A pecl_versions=(
 )
 
 declare -A install_extras=(
-  ['stable-debian']='\nRUN set -ex; \\\n    fetchDeps=" \\\n        gnupg \\\n    "; \\\n    apt-get update; \\\n    apt-get install -y --no-install-recommends $fetchDeps; \\\n    \\\n    export GNUPGHOME="$(mktemp -d)"; \\\n    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287; \\\n    \\\n    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz \\\n        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"; \\\n    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc \\\n        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc"; \\\n    gpg --batch --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz; \\\n    echo "${FRIENDICA_DOWNLOAD_SHA256} *friendica-full-${FRIENDICA_VERSION}.tar.gz" \| sha256sum -c; \\\n    tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/; \\\n    rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc; \\\n    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica; \\\n    chmod 777 /usr/src/friendica/view/smarty3; \\\n    \\\n    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \\\n            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \\\n    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc \\\n            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \\\n    gpg --batch --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \\\n    echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" \| sha256sum -c; \\\n    mkdir -p /usr/src/friendica/proxy; \\\n    mkdir -p /usr/src/friendica/addon; \\\n    tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1; \\\n    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc; \\\n    \\\n    gpgconf --kill all; \\\n    rm -rf "$GNUPGHOME"; \\\n    \\\n    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \\\n    rm -rf /var/lib/apt/lists/*\n'
-  ['stable-alpine']='\nRUN set -ex; \\\n     apk add --no-cache --virtual .fetch-deps \\\n            gnupg \\\n        ; \\\n        \\\n    export GNUPGHOME="$(mktemp -d)"; \\\n    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287; \\\n    \\\n    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz \\\n        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"; \\\n    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc \\\n        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc"; \\\n    gpg --batch --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz; \\\n    echo "${FRIENDICA_DOWNLOAD_SHA256} *friendica-full-${FRIENDICA_VERSION}.tar.gz" \| sha256sum -c; \\\n    tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/; \\\n    rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc; \\\n    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica; \\\n    chmod 777 /usr/src/friendica/view/smarty3; \\\n    \\\n    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \\\n            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \\\n    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc \\\n            "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \\\n    gpg --batch --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \\\n    echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" \| sha256sum -c; \\\n    mkdir -p /usr/src/friendica/proxy; \\\n    mkdir -p /usr/src/friendica/addon; \\\n    tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1; \\\n    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc; \\\n    \\\n    gpgconf --kill all; \\\n    rm -rf "$GNUPGHOME"; \\\n    \\\n    apk del .fetch-deps\n'
-  ['develop-debian']='RUN set -ex; \\\n    fetchDeps=" \\\n        gnupg \\\n    "; \\\n    apt-get update; \\\n    apt-get install -y --no-install-recommends $fetchDeps;\n'
-  ['develop-alpine']='RUN set -ex; \\\n     apk add --no-cache --virtual .fetch-deps \\\n            gnupg \\\n        ;\n'
+  ['stable-debian']='RUN set -ex; \
+    fetchDeps=" \
+        gnupg \
+    "; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps; \
+    \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287; \
+    \
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz \
+        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"; \
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc \
+        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc"; \
+    gpg --batch --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz; \
+    echo "${FRIENDICA_DOWNLOAD_SHA256} *friendica-full-${FRIENDICA_VERSION}.tar.gz" \| sha256sum -c; \
+    tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/; \
+    rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc; \
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica; \
+    chmod 777 /usr/src/friendica/view/smarty3; \
+    \
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
+    gpg --batch --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
+    echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" \| sha256sum -c; \
+    mkdir -p /usr/src/friendica/proxy; \
+    mkdir -p /usr/src/friendica/addon; \
+    tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1; \
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc; \
+    \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME"; \
+    \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
+    rm -rf /var/lib/apt/lists/*'
+  ['stable-alpine']='RUN set -ex; \
+    apk add --no-cache --virtual .fetch-deps \
+      gnupg \
+    ; \
+    \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 08656443618E6567A39524083EE197EF3F9E4287; \
+    \
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz \
+        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz"; \
+    curl -fsSL -o friendica-full-${FRIENDICA_VERSION}.tar.gz.asc \
+        "https://files.friendi.ca/friendica-full-${FRIENDICA_VERSION}.tar.gz.asc"; \
+    gpg --batch --verify friendica-full-${FRIENDICA_VERSION}.tar.gz.asc friendica-full-${FRIENDICA_VERSION}.tar.gz; \
+    echo "${FRIENDICA_DOWNLOAD_SHA256} *friendica-full-${FRIENDICA_VERSION}.tar.gz" \| sha256sum -c; \
+    tar -xzf friendica-full-${FRIENDICA_VERSION}.tar.gz -C /usr/src/; \
+    rm friendica-full-${FRIENDICA_VERSION}.tar.gz friendica-full-${FRIENDICA_VERSION}.tar.gz.asc; \
+    mv -f /usr/src/friendica-full-${FRIENDICA_VERSION}/ /usr/src/friendica; \
+    chmod 777 /usr/src/friendica/view/smarty3; \
+    \
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz"; \
+    curl -fsSL -o friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc \
+        "https://files.friendi.ca/friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc"; \
+    gpg --batch --verify friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc friendica-addons-${FRIENDICA_ADDONS}.tar.gz; \
+    echo "${FRIENDICA_DOWNLOAD_ADDONS_SHA256} *friendica-addons-${FRIENDICA_ADDONS}.tar.gz" \| sha256sum -c; \
+    mkdir -p /usr/src/friendica/proxy; \
+    mkdir -p /usr/src/friendica/addon; \
+    tar -xzf friendica-addons-${FRIENDICA_ADDONS}.tar.gz -C /usr/src/friendica/addon --strip-components=1; \
+    rm friendica-addons-${FRIENDICA_ADDONS}.tar.gz friendica-addons-${FRIENDICA_ADDONS}.tar.gz.asc; \
+    \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME"; \
+    \
+    apk del .fetch-deps'
+  ['develop-debian']='RUN set -ex; \
+    fetchDeps=" \
+      gnupg \
+    "; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $fetchDeps;' \
+  ['develop-alpine']='RUN set -ex; \
+    apk add --no-cache --virtual .fetch-deps \
+      gnupg \
+    ;'
 )
 
 variants=(
@@ -141,9 +226,9 @@ function create_variant() {
     s/%%VARIANT%%/'"$variant"'/g;
     s/%%VERSION%%/'"${2:-${1}}"'/g;
     s/%%CMD%%/'"${cmd[$variant]}"'/g;
-    s|%%VARIANT_EXTRAS%%|'"${extras[$variant]}"'|g;
+    s|%%VARIANT_EXTRAS%%|'"${extras[$variant]//$'\n'/\\\\n}"'|g;
     s|%%DOWNLOAD_SHA256%%|'"$(get_sha256_string $install_type ${2:-${1}})"'|g;
-    s|%%INSTALL_EXTRAS%%|'"${install_extras[$install_type-${base[$variant]}]}"'|g;
+    s|%%INSTALL_EXTRAS%%|'"${install_extras[$install_type-${base[$variant]}]//$'\n'/\\\\n}"'|g;
     s/%%APCU_VERSION%%/'"${pecl_versions[APCu]}"'/g;
     s/%%IMAGICK_VERSION%%/'"${pecl_versions[imagick]}"'/g;
     s/%%MEMCACHED_VERSION%%/'"${pecl_versions[memcached]}"'/g;


### PR DESCRIPTION
This PR makes the update.sh script more readable and easier to maintain by allowing multiline strings for the extras and install_extras arrays.