### PR TITLE
Fix display of remote ip in php log

### DIFF
--- a/2024.08/apache/Dockerfile
+++ b/2024.08/apache/Dockerfile
@@ -158,7 +158,8 @@ RUN set -ex; \
 RUN set -ex; \
     a2enmod rewrite remoteip; \
     { \
-     echo RemoteIPHeader X-Real-IP; \
+     echo RemoteIPHeader X-Forwarded-For; \
+     echo RemoteIPTrustedProxy 127.0.0.0/8; \
      echo RemoteIPTrustedProxy 10.0.0.0/8; \
      echo RemoteIPTrustedProxy 172.16.0.0/12; \
      echo RemoteIPTrustedProxy 192.168.0.0/16; \

--- a/2024.08/fpm-alpine/Dockerfile
+++ b/2024.08/fpm-alpine/Dockerfile
@@ -134,7 +134,8 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-
+RUN set -ex; \
+    echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
 
 VOLUME /var/www/html
 

--- a/2024.08/fpm/Dockerfile
+++ b/2024.08/fpm/Dockerfile
@@ -155,7 +155,8 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-
+RUN set -ex; \
+    echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
 
 VOLUME /var/www/html
 

--- a/2024.12/apache/Dockerfile
+++ b/2024.12/apache/Dockerfile
@@ -158,7 +158,8 @@ RUN set -ex; \
 RUN set -ex; \
     a2enmod rewrite remoteip; \
     { \
-     echo RemoteIPHeader X-Real-IP; \
+     echo RemoteIPHeader X-Forwarded-For; \
+     echo RemoteIPTrustedProxy 127.0.0.0/8; \
      echo RemoteIPTrustedProxy 10.0.0.0/8; \
      echo RemoteIPTrustedProxy 172.16.0.0/12; \
      echo RemoteIPTrustedProxy 192.168.0.0/16; \

--- a/2024.12/fpm-alpine/Dockerfile
+++ b/2024.12/fpm-alpine/Dockerfile
@@ -134,7 +134,8 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-
+RUN set -ex; \
+    echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
 
 VOLUME /var/www/html
 

--- a/2024.12/fpm/Dockerfile
+++ b/2024.12/fpm/Dockerfile
@@ -155,7 +155,8 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-
+RUN set -ex; \
+    echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
 
 VOLUME /var/www/html
 

--- a/2025.02-dev/apache/Dockerfile
+++ b/2025.02-dev/apache/Dockerfile
@@ -158,7 +158,8 @@ RUN set -ex; \
 RUN set -ex; \
     a2enmod rewrite remoteip; \
     { \
-     echo RemoteIPHeader X-Real-IP; \
+     echo RemoteIPHeader X-Forwarded-For; \
+     echo RemoteIPTrustedProxy 127.0.0.0/8; \
      echo RemoteIPTrustedProxy 10.0.0.0/8; \
      echo RemoteIPTrustedProxy 172.16.0.0/12; \
      echo RemoteIPTrustedProxy 192.168.0.0/16; \

--- a/2025.02-dev/fpm-alpine/Dockerfile
+++ b/2025.02-dev/fpm-alpine/Dockerfile
@@ -134,7 +134,8 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-
+RUN set -ex; \
+    echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
 
 VOLUME /var/www/html
 

--- a/2025.02-dev/fpm/Dockerfile
+++ b/2025.02-dev/fpm/Dockerfile
@@ -155,7 +155,8 @@ RUN set -ex; \
     chown -R www-data:root /var/www; \
     chmod -R g=u /var/www
 
-
+RUN set -ex; \
+    echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
 
 VOLUME /var/www/html
 

--- a/update.sh
+++ b/update.sh
@@ -21,14 +21,17 @@ declare -A extras=(
   [apache]='RUN set -ex; \
     a2enmod rewrite remoteip; \
     { \
-     echo RemoteIPHeader X-Real-IP; \
+     echo RemoteIPHeader X-Forwarded-For; \
+     echo RemoteIPTrustedProxy 127.0.0.0/8; \
      echo RemoteIPTrustedProxy 10.0.0.0/8; \
      echo RemoteIPTrustedProxy 172.16.0.0/12; \
      echo RemoteIPTrustedProxy 192.168.0.0/16; \
     } > /etc/apache2/conf-available/remoteip.conf; \
     a2enconf remoteip;'
-  [fpm]=''
-  [fpm-alpine]=''
+  [fpm]='RUN set -ex; \
+    echo access.format = '\''%{REMOTE_ADDR}e - %u %t \"%m %r\" %s'\'' >> /usr/local/etc/php-fpm.d/docker.conf;'
+  [fpm-alpine]='RUN set -ex; \
+    echo access.format = '\''%{REMOTE_ADDR}e - %u %t \"%m %r\" %s'\'' >> /usr/local/etc/php-fpm.d/docker.conf;'
 )
 
 declare -A entrypoints=(


### PR DESCRIPTION
Based on #289 I create this PR to collect the changes needed to ensure that the original requesters ip is used for logging, etc.

This is what is to be done now:

- @m33m33 Looking in https://github.com/friendica/friendica/pull/11680 I believe logging the correct ip should be possible already if the Friendica configuration is set accordingly. We need to figure out how to add this correctly to the docker configuration. We may also need to add another optional env variable with a proper default for this.

- For the Apache image the mod_remoteip needs to be adjusted.

- We need to document how this is working

Co-authored-by: @m33m33
