### PR TITLE
/var/www/data is now a volume

### DIFF
--- a/.config/zz-docker.config.php
+++ b/.config/zz-docker.config.php
@@ -16,7 +16,7 @@ $config = [
 		'loglevel' => 'notice',
 	],
 	'storage' => [
-		'filesystem_path' => '/var/www/html/storage',
+		'filesystem_path' => '/var/www/data',
 	],
 ];
 

--- a/2024.08/apache/Dockerfile
+++ b/2024.08/apache/Dockerfile
@@ -149,11 +149,7 @@ RUN set -ex; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
-    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini; \
-    \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
     a2enmod rewrite remoteip; \
@@ -166,7 +162,12 @@ RUN set -ex; \
     } > /etc/apache2/conf-available/remoteip.conf; \
     a2enconf remoteip;
 
+RUN set -ex; \
+    mkdir -p -m 775 /var/www/data; \
+    chown -R www-data:www-data /var/www/data
+
 VOLUME /var/www/html
+VOLUME /var/www/data
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39

--- a/2024.08/apache/config/zz-docker.config.php
+++ b/2024.08/apache/config/zz-docker.config.php
@@ -16,7 +16,7 @@ $config = [
 		'loglevel' => 'notice',
 	],
 	'storage' => [
-		'filesystem_path' => '/var/www/html/storage',
+		'filesystem_path' => '/var/www/data',
 	],
 ];
 

--- a/2024.08/fpm-alpine/Dockerfile
+++ b/2024.08/fpm-alpine/Dockerfile
@@ -128,16 +128,17 @@ RUN set -ex; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
-    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini; \
-    \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
     echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
 
+RUN set -ex; \
+    mkdir -p -m 775 /var/www/data; \
+    chown -R www-data:www-data /var/www/data
+
 VOLUME /var/www/html
+VOLUME /var/www/data
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39

--- a/2024.08/fpm-alpine/config/zz-docker.config.php
+++ b/2024.08/fpm-alpine/config/zz-docker.config.php
@@ -16,7 +16,7 @@ $config = [
 		'loglevel' => 'notice',
 	],
 	'storage' => [
-		'filesystem_path' => '/var/www/html/storage',
+		'filesystem_path' => '/var/www/data',
 	],
 ];
 

--- a/2024.08/fpm/Dockerfile
+++ b/2024.08/fpm/Dockerfile
@@ -149,16 +149,17 @@ RUN set -ex; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
-    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini; \
-    \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
     echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
 
+RUN set -ex; \
+    mkdir -p -m 775 /var/www/data; \
+    chown -R www-data:www-data /var/www/data
+
 VOLUME /var/www/html
+VOLUME /var/www/data
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39

--- a/2024.08/fpm/config/zz-docker.config.php
+++ b/2024.08/fpm/config/zz-docker.config.php
@@ -16,7 +16,7 @@ $config = [
 		'loglevel' => 'notice',
 	],
 	'storage' => [
-		'filesystem_path' => '/var/www/html/storage',
+		'filesystem_path' => '/var/www/data',
 	],
 ];
 

--- a/2024.12/apache/Dockerfile
+++ b/2024.12/apache/Dockerfile
@@ -149,11 +149,7 @@ RUN set -ex; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
-    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini; \
-    \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
     a2enmod rewrite remoteip; \
@@ -166,7 +162,12 @@ RUN set -ex; \
     } > /etc/apache2/conf-available/remoteip.conf; \
     a2enconf remoteip;
 
+RUN set -ex; \
+    mkdir -p -m 775 /var/www/data; \
+    chown -R www-data:www-data /var/www/data
+
 VOLUME /var/www/html
+VOLUME /var/www/data
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39

--- a/2024.12/apache/config/zz-docker.config.php
+++ b/2024.12/apache/config/zz-docker.config.php
@@ -16,7 +16,7 @@ $config = [
 		'loglevel' => 'notice',
 	],
 	'storage' => [
-		'filesystem_path' => '/var/www/html/storage',
+		'filesystem_path' => '/var/www/data',
 	],
 ];
 

--- a/2024.12/fpm-alpine/Dockerfile
+++ b/2024.12/fpm-alpine/Dockerfile
@@ -128,16 +128,17 @@ RUN set -ex; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
-    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini; \
-    \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
     echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
 
+RUN set -ex; \
+    mkdir -p -m 775 /var/www/data; \
+    chown -R www-data:www-data /var/www/data
+
 VOLUME /var/www/html
+VOLUME /var/www/data
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39

--- a/2024.12/fpm-alpine/config/zz-docker.config.php
+++ b/2024.12/fpm-alpine/config/zz-docker.config.php
@@ -16,7 +16,7 @@ $config = [
 		'loglevel' => 'notice',
 	],
 	'storage' => [
-		'filesystem_path' => '/var/www/html/storage',
+		'filesystem_path' => '/var/www/data',
 	],
 ];
 

--- a/2024.12/fpm/Dockerfile
+++ b/2024.12/fpm/Dockerfile
@@ -149,16 +149,17 @@ RUN set -ex; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
-    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini; \
-    \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
     echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
 
+RUN set -ex; \
+    mkdir -p -m 775 /var/www/data; \
+    chown -R www-data:www-data /var/www/data
+
 VOLUME /var/www/html
+VOLUME /var/www/data
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39

--- a/2024.12/fpm/config/zz-docker.config.php
+++ b/2024.12/fpm/config/zz-docker.config.php
@@ -16,7 +16,7 @@ $config = [
 		'loglevel' => 'notice',
 	],
 	'storage' => [
-		'filesystem_path' => '/var/www/html/storage',
+		'filesystem_path' => '/var/www/data',
 	],
 ];
 

--- a/2025.02-dev/apache/Dockerfile
+++ b/2025.02-dev/apache/Dockerfile
@@ -149,11 +149,7 @@ RUN set -ex; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
-    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini; \
-    \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
     a2enmod rewrite remoteip; \
@@ -166,7 +162,12 @@ RUN set -ex; \
     } > /etc/apache2/conf-available/remoteip.conf; \
     a2enconf remoteip;
 
+RUN set -ex; \
+    mkdir -p -m 775 /var/www/data; \
+    chown -R www-data:www-data /var/www/data
+
 VOLUME /var/www/html
+VOLUME /var/www/data
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39

--- a/2025.02-dev/apache/config/zz-docker.config.php
+++ b/2025.02-dev/apache/config/zz-docker.config.php
@@ -16,7 +16,7 @@ $config = [
 		'loglevel' => 'notice',
 	],
 	'storage' => [
-		'filesystem_path' => '/var/www/html/storage',
+		'filesystem_path' => '/var/www/data',
 	],
 ];
 

--- a/2025.02-dev/fpm-alpine/Dockerfile
+++ b/2025.02-dev/fpm-alpine/Dockerfile
@@ -128,16 +128,17 @@ RUN set -ex; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
-    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini; \
-    \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
     echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
 
+RUN set -ex; \
+    mkdir -p -m 775 /var/www/data; \
+    chown -R www-data:www-data /var/www/data
+
 VOLUME /var/www/html
+VOLUME /var/www/data
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39

--- a/2025.02-dev/fpm-alpine/config/zz-docker.config.php
+++ b/2025.02-dev/fpm-alpine/config/zz-docker.config.php
@@ -16,7 +16,7 @@ $config = [
 		'loglevel' => 'notice',
 	],
 	'storage' => [
-		'filesystem_path' => '/var/www/html/storage',
+		'filesystem_path' => '/var/www/data',
 	],
 ];
 

--- a/2025.02-dev/fpm/Dockerfile
+++ b/2025.02-dev/fpm/Dockerfile
@@ -149,16 +149,17 @@ RUN set -ex; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
-    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini; \
-    \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
     echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
 
+RUN set -ex; \
+    mkdir -p -m 775 /var/www/data; \
+    chown -R www-data:www-data /var/www/data
+
 VOLUME /var/www/html
+VOLUME /var/www/data
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39

--- a/2025.02-dev/fpm/config/zz-docker.config.php
+++ b/2025.02-dev/fpm/config/zz-docker.config.php
@@ -16,7 +16,7 @@ $config = [
 		'loglevel' => 'notice',
 	],
 	'storage' => [
-		'filesystem_path' => '/var/www/html/storage',
+		'filesystem_path' => '/var/www/data',
 	],
 ];
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -127,15 +127,16 @@ RUN set -ex; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
-    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini; \
-    \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 %%VARIANT_EXTRAS%%
 
+RUN set -ex; \
+    mkdir -p -m 775 /var/www/data; \
+    chown -R www-data:www-data /var/www/data
+
 VOLUME /var/www/html
+VOLUME /var/www/data
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -148,15 +148,16 @@ RUN set -ex; \
         echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
         echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
-    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini; \
-    \
-    mkdir /var/www/data; \
-    chown -R www-data:root /var/www; \
-    chmod -R g=u /var/www
+    ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 %%VARIANT_EXTRAS%%
 
+RUN set -ex; \
+    mkdir -p -m 775 /var/www/data; \
+    chown -R www-data:www-data /var/www/data
+
 VOLUME /var/www/html
+VOLUME /var/www/data
 
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS 39


### PR DESCRIPTION
Fixes: #290
 
/var/www/data is now a dedicated volume by default. This prevents writes to the container's image volume.

Co-authored-by: @m33m33