### PR TITLE
Upgraded the Debian version to bookworm

### DIFF
--- a/2024.08/apache/Dockerfile
+++ b/2024.08/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.2-apache-bullseye
+FROM php:8.2-apache-bookworm
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -75,7 +75,7 @@ RUN set -ex; \
         libmagickcore-6.q16-6-extra \
     ; \
     \
-        debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     \
     docker-php-ext-configure gd \
         --with-freetype \
@@ -101,7 +101,7 @@ RUN set -ex; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install apcu-5.1.24; \
     pecl install memcached-3.3.0; \
-    pecl install redis-6.1.0; \
+    pecl install redis-6.1.0 --configureoptions 'enable-redis-zstd="yes" enable-redis-lz4="yes"'; \
     pecl install imagick-3.7.0; \
     \
     docker-php-ext-enable \
@@ -110,12 +110,13 @@ RUN set -ex; \
         redis \
         imagick \
     ; \
+    rm -r /tmp/pear; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
     apt-mark auto '.*' > /dev/null; \
     apt-mark manual $savedAptMark; \
     ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-        | awk '/=>/ { print $3 }' \
+        | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
         | sort -u \
         | xargs -r dpkg-query -S \
         | cut -d: -f1 \
@@ -135,7 +136,9 @@ RUN set -ex; \
         echo 'opcache.max_accelerated_files=10000'; \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.save_comments=1'; \
-        echo 'opcache.revalidte_freq=1'; \
+        echo 'opcache.revalidte_freq=60'; \
+        echo 'opcache.jit=tracing'; \
+        echo 'opcache.jit_buffer_size=32M'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
     \
     { \
@@ -151,8 +154,7 @@ RUN set -ex; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
     ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
-RUN set -ex; \
-    a2enmod rewrite remoteip; \
+RUN a2enmod headers rewrite remoteip; \
     { \
      echo RemoteIPHeader X-Forwarded-For; \
      echo RemoteIPTrustedProxy 127.0.0.0/8; \

--- a/2024.08/fpm-alpine/Dockerfile
+++ b/2024.08/fpm-alpine/Dockerfile
@@ -131,7 +131,7 @@ RUN set -ex; \
     ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
-    echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
+    echo access.format = '"%{REMOTE_ADDR}e - %u %t \"%m %r\" %s"' >> /usr/local/etc/php-fpm.d/docker.conf;
 
 RUN set -ex; \
     mkdir -p -m 775 /var/www/data; \

--- a/2024.08/fpm/Dockerfile
+++ b/2024.08/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.2-fpm-bullseye
+FROM php:8.2-fpm-bookworm
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -75,7 +75,7 @@ RUN set -ex; \
         libmagickcore-6.q16-6-extra \
     ; \
     \
-        debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     \
     docker-php-ext-configure gd \
         --with-freetype \
@@ -101,7 +101,7 @@ RUN set -ex; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install apcu-5.1.24; \
     pecl install memcached-3.3.0; \
-    pecl install redis-6.1.0; \
+    pecl install redis-6.1.0 --configureoptions 'enable-redis-zstd="yes" enable-redis-lz4="yes"'; \
     pecl install imagick-3.7.0; \
     \
     docker-php-ext-enable \
@@ -110,12 +110,13 @@ RUN set -ex; \
         redis \
         imagick \
     ; \
+    rm -r /tmp/pear; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
     apt-mark auto '.*' > /dev/null; \
     apt-mark manual $savedAptMark; \
     ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-        | awk '/=>/ { print $3 }' \
+        | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
         | sort -u \
         | xargs -r dpkg-query -S \
         | cut -d: -f1 \
@@ -135,7 +136,9 @@ RUN set -ex; \
         echo 'opcache.max_accelerated_files=10000'; \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.save_comments=1'; \
-        echo 'opcache.revalidte_freq=1'; \
+        echo 'opcache.revalidte_freq=60'; \
+        echo 'opcache.jit=tracing'; \
+        echo 'opcache.jit_buffer_size=32M'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
     \
     { \
@@ -152,7 +155,7 @@ RUN set -ex; \
     ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
-    echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
+    echo access.format = '"%{REMOTE_ADDR}e - %u %t \"%m %r\" %s"' >> /usr/local/etc/php-fpm.d/docker.conf;
 
 RUN set -ex; \
     mkdir -p -m 775 /var/www/data; \

--- a/2024.12/apache/Dockerfile
+++ b/2024.12/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.2-apache-bullseye
+FROM php:8.2-apache-bookworm
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -75,7 +75,7 @@ RUN set -ex; \
         libmagickcore-6.q16-6-extra \
     ; \
     \
-        debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     \
     docker-php-ext-configure gd \
         --with-freetype \
@@ -101,7 +101,7 @@ RUN set -ex; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install apcu-5.1.24; \
     pecl install memcached-3.3.0; \
-    pecl install redis-6.1.0; \
+    pecl install redis-6.1.0 --configureoptions 'enable-redis-zstd="yes" enable-redis-lz4="yes"'; \
     pecl install imagick-3.7.0; \
     \
     docker-php-ext-enable \
@@ -110,12 +110,13 @@ RUN set -ex; \
         redis \
         imagick \
     ; \
+    rm -r /tmp/pear; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
     apt-mark auto '.*' > /dev/null; \
     apt-mark manual $savedAptMark; \
     ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-        | awk '/=>/ { print $3 }' \
+        | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
         | sort -u \
         | xargs -r dpkg-query -S \
         | cut -d: -f1 \
@@ -135,7 +136,9 @@ RUN set -ex; \
         echo 'opcache.max_accelerated_files=10000'; \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.save_comments=1'; \
-        echo 'opcache.revalidte_freq=1'; \
+        echo 'opcache.revalidte_freq=60'; \
+        echo 'opcache.jit=tracing'; \
+        echo 'opcache.jit_buffer_size=32M'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
     \
     { \
@@ -151,8 +154,7 @@ RUN set -ex; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
     ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
-RUN set -ex; \
-    a2enmod rewrite remoteip; \
+RUN a2enmod headers rewrite remoteip; \
     { \
      echo RemoteIPHeader X-Forwarded-For; \
      echo RemoteIPTrustedProxy 127.0.0.0/8; \

--- a/2024.12/fpm-alpine/Dockerfile
+++ b/2024.12/fpm-alpine/Dockerfile
@@ -131,7 +131,7 @@ RUN set -ex; \
     ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
-    echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
+    echo access.format = '"%{REMOTE_ADDR}e - %u %t \"%m %r\" %s"' >> /usr/local/etc/php-fpm.d/docker.conf;
 
 RUN set -ex; \
     mkdir -p -m 775 /var/www/data; \

--- a/2024.12/fpm/Dockerfile
+++ b/2024.12/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.2-fpm-bullseye
+FROM php:8.2-fpm-bookworm
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -75,7 +75,7 @@ RUN set -ex; \
         libmagickcore-6.q16-6-extra \
     ; \
     \
-        debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     \
     docker-php-ext-configure gd \
         --with-freetype \
@@ -101,7 +101,7 @@ RUN set -ex; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install apcu-5.1.24; \
     pecl install memcached-3.3.0; \
-    pecl install redis-6.1.0; \
+    pecl install redis-6.1.0 --configureoptions 'enable-redis-zstd="yes" enable-redis-lz4="yes"'; \
     pecl install imagick-3.7.0; \
     \
     docker-php-ext-enable \
@@ -110,12 +110,13 @@ RUN set -ex; \
         redis \
         imagick \
     ; \
+    rm -r /tmp/pear; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
     apt-mark auto '.*' > /dev/null; \
     apt-mark manual $savedAptMark; \
     ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-        | awk '/=>/ { print $3 }' \
+        | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
         | sort -u \
         | xargs -r dpkg-query -S \
         | cut -d: -f1 \
@@ -135,7 +136,9 @@ RUN set -ex; \
         echo 'opcache.max_accelerated_files=10000'; \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.save_comments=1'; \
-        echo 'opcache.revalidte_freq=1'; \
+        echo 'opcache.revalidte_freq=60'; \
+        echo 'opcache.jit=tracing'; \
+        echo 'opcache.jit_buffer_size=32M'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
     \
     { \
@@ -152,7 +155,7 @@ RUN set -ex; \
     ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
-    echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
+    echo access.format = '"%{REMOTE_ADDR}e - %u %t \"%m %r\" %s"' >> /usr/local/etc/php-fpm.d/docker.conf;
 
 RUN set -ex; \
     mkdir -p -m 775 /var/www/data; \

--- a/2025.02-dev/apache/Dockerfile
+++ b/2025.02-dev/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.2-apache-bullseye
+FROM php:8.2-apache-bookworm
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -75,7 +75,7 @@ RUN set -ex; \
         libmagickcore-6.q16-6-extra \
     ; \
     \
-        debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     \
     docker-php-ext-configure gd \
         --with-freetype \
@@ -101,7 +101,7 @@ RUN set -ex; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install apcu-5.1.24; \
     pecl install memcached-3.3.0; \
-    pecl install redis-6.1.0; \
+    pecl install redis-6.1.0 --configureoptions 'enable-redis-zstd="yes" enable-redis-lz4="yes"'; \
     pecl install imagick-3.7.0; \
     \
     docker-php-ext-enable \
@@ -110,12 +110,13 @@ RUN set -ex; \
         redis \
         imagick \
     ; \
+    rm -r /tmp/pear; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
     apt-mark auto '.*' > /dev/null; \
     apt-mark manual $savedAptMark; \
     ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-        | awk '/=>/ { print $3 }' \
+        | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
         | sort -u \
         | xargs -r dpkg-query -S \
         | cut -d: -f1 \
@@ -135,7 +136,9 @@ RUN set -ex; \
         echo 'opcache.max_accelerated_files=10000'; \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.save_comments=1'; \
-        echo 'opcache.revalidte_freq=1'; \
+        echo 'opcache.revalidte_freq=60'; \
+        echo 'opcache.jit=tracing'; \
+        echo 'opcache.jit_buffer_size=32M'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
     \
     { \
@@ -151,8 +154,7 @@ RUN set -ex; \
     } > /usr/local/etc/php/conf.d/friendica.ini; \
     ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
-RUN set -ex; \
-    a2enmod rewrite remoteip; \
+RUN a2enmod headers rewrite remoteip; \
     { \
      echo RemoteIPHeader X-Forwarded-For; \
      echo RemoteIPTrustedProxy 127.0.0.0/8; \

--- a/2025.02-dev/fpm-alpine/Dockerfile
+++ b/2025.02-dev/fpm-alpine/Dockerfile
@@ -131,7 +131,7 @@ RUN set -ex; \
     ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
-    echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
+    echo access.format = '"%{REMOTE_ADDR}e - %u %t \"%m %r\" %s"' >> /usr/local/etc/php-fpm.d/docker.conf;
 
 RUN set -ex; \
     mkdir -p -m 775 /var/www/data; \

--- a/2025.02-dev/fpm/Dockerfile
+++ b/2025.02-dev/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.2-fpm-bullseye
+FROM php:8.2-fpm-bookworm
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -75,7 +75,7 @@ RUN set -ex; \
         libmagickcore-6.q16-6-extra \
     ; \
     \
-        debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     \
     docker-php-ext-configure gd \
         --with-freetype \
@@ -101,7 +101,7 @@ RUN set -ex; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install apcu-5.1.24; \
     pecl install memcached-3.3.0; \
-    pecl install redis-6.1.0; \
+    pecl install redis-6.1.0 --configureoptions 'enable-redis-zstd="yes" enable-redis-lz4="yes"'; \
     pecl install imagick-3.7.0; \
     \
     docker-php-ext-enable \
@@ -110,12 +110,13 @@ RUN set -ex; \
         redis \
         imagick \
     ; \
+    rm -r /tmp/pear; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
     apt-mark auto '.*' > /dev/null; \
     apt-mark manual $savedAptMark; \
     ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-        | awk '/=>/ { print $3 }' \
+        | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
         | sort -u \
         | xargs -r dpkg-query -S \
         | cut -d: -f1 \
@@ -135,7 +136,9 @@ RUN set -ex; \
         echo 'opcache.max_accelerated_files=10000'; \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.save_comments=1'; \
-        echo 'opcache.revalidte_freq=1'; \
+        echo 'opcache.revalidte_freq=60'; \
+        echo 'opcache.jit=tracing'; \
+        echo 'opcache.jit_buffer_size=32M'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
     \
     { \
@@ -152,7 +155,7 @@ RUN set -ex; \
     ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN set -ex; \
-    echo access.format = '%{REMOTE_ADDR}e - %u %t "%m %r" %s' >> /usr/local/etc/php-fpm.d/docker.conf;
+    echo access.format = '"%{REMOTE_ADDR}e - %u %t \"%m %r\" %s"' >> /usr/local/etc/php-fpm.d/docker.conf;
 
 RUN set -ex; \
     mkdir -p -m 775 /var/www/data; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,4 +1,4 @@
-FROM php:%%PHP_VERSION%%-%%VARIANT%%-bullseye
+FROM php:%%PHP_VERSION%%-%%VARIANT%%-bookworm
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -74,7 +74,7 @@ RUN set -ex; \
         libmagickcore-6.q16-6-extra \
     ; \
     \
-        debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     \
     docker-php-ext-configure gd \
         --with-freetype \
@@ -100,7 +100,7 @@ RUN set -ex; \
 # pecl will claim success even if one install fails, so we need to perform each install separately
     pecl install apcu-%%APCU_VERSION%%; \
     pecl install memcached-%%MEMCACHED_VERSION%%; \
-    pecl install redis-%%REDIS_VERSION%%; \
+    pecl install redis-%%REDIS_VERSION%% --configureoptions 'enable-redis-zstd="yes" enable-redis-lz4="yes"'; \
     pecl install imagick-%%IMAGICK_VERSION%%; \
     \
     docker-php-ext-enable \
@@ -109,12 +109,13 @@ RUN set -ex; \
         redis \
         imagick \
     ; \
+    rm -r /tmp/pear; \
     \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
     apt-mark auto '.*' > /dev/null; \
     apt-mark manual $savedAptMark; \
     ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-        | awk '/=>/ { print $3 }' \
+        | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
         | sort -u \
         | xargs -r dpkg-query -S \
         | cut -d: -f1 \
@@ -134,7 +135,9 @@ RUN set -ex; \
         echo 'opcache.max_accelerated_files=10000'; \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.save_comments=1'; \
-        echo 'opcache.revalidte_freq=1'; \
+        echo 'opcache.revalidte_freq=60'; \
+        echo 'opcache.jit=tracing'; \
+        echo 'opcache.jit_buffer_size=32M'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
     \
     { \

--- a/update.sh
+++ b/update.sh
@@ -18,8 +18,7 @@ declare -A base=(
 )
 
 declare -A extras=(
-  [apache]='RUN set -ex; \
-    a2enmod rewrite remoteip; \
+  [apache]='RUN a2enmod headers rewrite remoteip; \
     { \
      echo RemoteIPHeader X-Forwarded-For; \
      echo RemoteIPTrustedProxy 127.0.0.0/8; \
@@ -29,9 +28,9 @@ declare -A extras=(
     } > /etc/apache2/conf-available/remoteip.conf; \
     a2enconf remoteip;'
   [fpm]='RUN set -ex; \
-    echo access.format = '\''%{REMOTE_ADDR}e - %u %t \"%m %r\" %s'\'' >> /usr/local/etc/php-fpm.d/docker.conf;'
+    echo access.format = '\''\"%{REMOTE_ADDR}e - %u %t \\\"%m %r\\\" %s\"'\'' >> /usr/local/etc/php-fpm.d/docker.conf;'
   [fpm-alpine]='RUN set -ex; \
-    echo access.format = '\''%{REMOTE_ADDR}e - %u %t \"%m %r\" %s'\'' >> /usr/local/etc/php-fpm.d/docker.conf;'
+    echo access.format = '\''\"%{REMOTE_ADDR}e - %u %t \\\"%m %r\\\" %s'\"\'' >> /usr/local/etc/php-fpm.d/docker.conf;'
 )
 
 declare -A entrypoints=(


### PR DESCRIPTION
This is the long awaited upgrade to bookworm for the Debian based images.

The alpine image is not affected by the change.

**A**) I tested the apache and the fpm image of version 2025.02-dev.

The following issues have been found:
- The registration of the first/admin user on the registration page fails. The user is created but no password is shown or send by email. See [#14823](https://github.com/friendica/friendica/issues/14832)
- The admin overview page is not working. As all other pages (including sub pages as /admin/site etc) are working I assume this is because it's dev sources. See [#14381](https://github.com/friendica/friendica/issues/14831)

Both issues do not seem to be docker related.

**B**) I also tested (or am still testing/running) 2024.12-fpm on my instance.

No problems so far.

