### PR TITLE
Update PHP version to 8.4

### DIFF
--- a/2026.01/apache/Dockerfile
+++ b/2026.01/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.3-apache-trixie
+FROM php:8.4-apache-trixie
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -176,7 +176,7 @@ VOLUME /var/www/data
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS=39
 ENV FRIENDICA_VERSION="2026.01"
-ENV FRIENDICA_DOWNLOAD_SHA256 "d985715f368e106f070519e1e30240b023f31604b3d9e4cc09f23d4d5150147d"
+ENV FRIENDICA_DOWNLOAD_SHA256="d985715f368e106f070519e1e30240b023f31604b3d9e4cc09f23d4d5150147d"
 
 RUN set -ex; \
     fetchDeps=" \

--- a/2026.01/fpm-alpine/Dockerfile
+++ b/2026.01/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:8.3-fpm-alpine
+FROM php:8.4-fpm-alpine
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -146,7 +146,7 @@ VOLUME /var/www/data
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS=39
 ENV FRIENDICA_VERSION="2026.01"
-ENV FRIENDICA_DOWNLOAD_SHA256 "d985715f368e106f070519e1e30240b023f31604b3d9e4cc09f23d4d5150147d"
+ENV FRIENDICA_DOWNLOAD_SHA256="d985715f368e106f070519e1e30240b023f31604b3d9e4cc09f23d4d5150147d"
 
 RUN set -ex; \
     apk add --no-cache --virtual .fetch-deps \

--- a/2026.01/fpm/Dockerfile
+++ b/2026.01/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.3-fpm-trixie
+FROM php:8.4-fpm-trixie
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -168,7 +168,7 @@ VOLUME /var/www/data
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS=39
 ENV FRIENDICA_VERSION="2026.01"
-ENV FRIENDICA_DOWNLOAD_SHA256 "d985715f368e106f070519e1e30240b023f31604b3d9e4cc09f23d4d5150147d"
+ENV FRIENDICA_DOWNLOAD_SHA256="d985715f368e106f070519e1e30240b023f31604b3d9e4cc09f23d4d5150147d"
 
 RUN set -ex; \
     fetchDeps=" \

--- a/2026.05/apache/Dockerfile
+++ b/2026.05/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.3-apache-trixie
+FROM php:8.4-apache-trixie
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -176,7 +176,7 @@ VOLUME /var/www/data
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS=39
 ENV FRIENDICA_VERSION="2026.05"
-ENV FRIENDICA_DOWNLOAD_SHA256 "b0a1e218c4a5a30d25b8be5a66cb97a4f4f802b98e7cf3d0d34ce045b2714ab2"
+ENV FRIENDICA_DOWNLOAD_SHA256="b0a1e218c4a5a30d25b8be5a66cb97a4f4f802b98e7cf3d0d34ce045b2714ab2"
 
 RUN set -ex; \
     fetchDeps=" \

--- a/2026.05/fpm-alpine/Dockerfile
+++ b/2026.05/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:8.3-fpm-alpine
+FROM php:8.4-fpm-alpine
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -146,7 +146,7 @@ VOLUME /var/www/data
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS=39
 ENV FRIENDICA_VERSION="2026.05"
-ENV FRIENDICA_DOWNLOAD_SHA256 "b0a1e218c4a5a30d25b8be5a66cb97a4f4f802b98e7cf3d0d34ce045b2714ab2"
+ENV FRIENDICA_DOWNLOAD_SHA256="b0a1e218c4a5a30d25b8be5a66cb97a4f4f802b98e7cf3d0d34ce045b2714ab2"
 
 RUN set -ex; \
     apk add --no-cache --virtual .fetch-deps \

--- a/2026.05/fpm/Dockerfile
+++ b/2026.05/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.3-fpm-trixie
+FROM php:8.4-fpm-trixie
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
@@ -168,7 +168,7 @@ VOLUME /var/www/data
 # 39 = LOG_PID | LOG_ODELAY | LOG_CONS | LOG_PERROR
 ENV FRIENDICA_SYSLOG_FLAGS=39
 ENV FRIENDICA_VERSION="2026.05"
-ENV FRIENDICA_DOWNLOAD_SHA256 "b0a1e218c4a5a30d25b8be5a66cb97a4f4f802b98e7cf3d0d34ce045b2714ab2"
+ENV FRIENDICA_DOWNLOAD_SHA256="b0a1e218c4a5a30d25b8be5a66cb97a4f4f802b98e7cf3d0d34ce045b2714ab2"
 
 RUN set -ex; \
     fetchDeps=" \

--- a/2026.08-dev/apache/Dockerfile
+++ b/2026.08-dev/apache/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.3-apache-trixie
+FROM php:8.4-apache-trixie
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2026.08-dev/fpm-alpine/Dockerfile
+++ b/2026.08-dev/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
-FROM php:8.3-fpm-alpine
+FROM php:8.4-fpm-alpine
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/2026.08-dev/fpm/Dockerfile
+++ b/2026.08-dev/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT: created by update.sh from Dockerfile-debian.template
-FROM php:8.3-fpm-trixie
+FROM php:8.4-fpm-trixie
 
 # entrypoint.sh and cron.sh dependencies
 RUN set -ex; \

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 declare -A php_version=(
-  [default]='8.3'
+  [default]='8.4'
 )
 
 declare -A cmd=(
@@ -178,7 +178,7 @@ function get_sha256_string() {
   if [[ $install_type == "develop" ]]; then
     echo ""
   else
-    echo "ENV FRIENDICA_DOWNLOAD_SHA256 \"$(curl -fsSL https://files.friendi.ca/friendica-all-in-one-${version}.tar.gz.sum256 | cut -d' ' -f1)\""
+    echo "ENV FRIENDICA_DOWNLOAD_SHA256=\"$(curl -fsSL https://files.friendi.ca/friendica-all-in-one-${version}.tar.gz.sum256 | cut -d' ' -f1)\""
   fi
 }
 


### PR DESCRIPTION
Update PHP for the upcoming version to 8.4

@nupplaphil: my container setup is working with 8.4 for two weeks now. I think, we should give it a try for the next builds.